### PR TITLE
LOOP-832: Added  Autocomplete deluxe to taxonomy fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",
         "drupal/adminimal_theme": "^1.6",
+        "drupal/autocomplete_deluxe": "^2.0@RC",
         "drupal/better_formats": "1.x-dev",
         "drupal/core-composer-scaffold": "^9.1",
         "drupal/core-project-message": "^9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88dfa721c776462ae34891d29f6f243a",
+    "content-hash": "0571fa9fcdc9090e54879293443db527",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1469,6 +1469,73 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/adminimal_theme",
                 "issues": "https://www.drupal.org/project/issues/adminimal_theme"
+            }
+        },
+        {
+            "name": "drupal/autocomplete_deluxe",
+            "version": "2.0.0-rc1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/autocomplete_deluxe.git",
+                "reference": "2.0.0-rc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/autocomplete_deluxe-2.0.0-rc1.zip",
+                "reference": "2.0.0-rc1",
+                "shasum": "9f3c63862652862322184bb892cc1fa80c9f47c1"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-rc1",
+                    "datestamp": "1592389562",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "RC releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Vardot",
+                    "homepage": "https://www.drupal.org/vardot",
+                    "role": "Maintenance for D8 and D9 versions"
+                },
+                {
+                    "name": "Mediacurrent",
+                    "homepage": "https://www.drupal.org/mediacurrent",
+                    "role": "Supporting organization"
+                },
+                {
+                    "name": "RajabNatshah",
+                    "homepage": "https://www.drupal.org/user/1414312"
+                },
+                {
+                    "name": "edwardchiapet",
+                    "homepage": "https://www.drupal.org/user/2354784"
+                },
+                {
+                    "name": "mpriscella",
+                    "homepage": "https://www.drupal.org/user/2354820"
+                },
+                {
+                    "name": "sepgil",
+                    "homepage": "https://www.drupal.org/user/512828"
+                }
+            ],
+            "description": "Enhanced autocomplete using Jquery UI autocomplete.",
+            "homepage": "https://www.drupal.org/project/autocomplete_deluxe",
+            "support": {
+                "source": "http://cgit.drupalcode.org/autocomplete_deluxe",
+                "issues": "https://www.drupal.org/project/issues/autocomplete_deluxe"
             }
         },
         {
@@ -8981,7 +9048,7 @@
         },
         {
             "name": "os2loop/os2loop_fixtures",
-            "version": "dev-develop",
+            "version": "dev-feature/LOOP-832-taxonomies",
             "dist": {
                 "type": "path",
                 "url": "web/profiles/custom/os2loop/modules/os2loop_fixtures",
@@ -11420,6 +11487,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "drupal/autocomplete_deluxe": 5,
         "drupal/better_formats": 20,
         "drupal/flag": 10,
         "drupal/masquerade": 10,

--- a/config/sync/core.entity_form_display.node.os2loop_documents_collection.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_documents_collection.default.yml
@@ -3,12 +3,13 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.os2loop_documents_collection.os2loop_documents_dc_content
     - field.field.node.os2loop_documents_collection.os2loop_shared_profession
     - field.field.node.os2loop_documents_collection.os2loop_shared_subject
     - field.field.node.os2loop_documents_collection.os2loop_shared_tags
-    - field.field.node.os2loop_documents_collection.os2loop_documents_dc_content
     - node.type.os2loop_documents_collection
   module:
+    - autocomplete_deluxe
     - text
 id: node.os2loop_documents_collection.default
 targetEntityType: node
@@ -17,12 +18,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   os2loop_documents_dc_content:
-    weight: 128
+    weight: 6
     settings:
       rows: 5
       placeholder: ''
@@ -30,59 +31,80 @@ content:
     type: text_textarea
     region: content
   os2loop_shared_profession:
-    weight: 125
+    weight: 9
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_subject:
-    weight: 126
+    weight: 7
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_tags:
-    weight: 127
+    weight: 8
     settings:
+      limit: '10'
+      min_length: '0'
+      delimiter: ''
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: '1'
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      not_found_message_allow: 0
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   promote:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 3
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 5
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 4
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -90,7 +112,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/sync/core.entity_form_display.node.os2loop_documents_document.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_documents_document.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.os2loop_documents_document.os2loop_shared_tags
     - node.type.os2loop_documents_document
   module:
+    - autocomplete_deluxe
     - paragraphs
 id: node.os2loop_documents_document.default
 targetEntityType: node
@@ -18,12 +19,12 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   os2loop_documents_document_autho:
-    weight: 122
+    weight: 7
     settings:
       size: 60
       placeholder: ''
@@ -32,7 +33,7 @@ content:
     region: content
   os2loop_documents_document_conte:
     type: entity_reference_paragraphs
-    weight: 121
+    weight: 6
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -43,59 +44,80 @@ content:
     third_party_settings: {  }
     region: content
   os2loop_shared_profession:
-    weight: 125
+    weight: 10
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_subject:
-    weight: 126
+    weight: 8
     settings:
+      limit: '10'
+      min_length: '0'
+      delimiter: ''
+      not_found_message: 'The term ''@term'' will be added'
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      not_found_message_allow: 0
+      new_terms: 0
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_tags:
-    weight: 127
+    weight: 9
     settings:
+      limit: '10'
+      min_length: '0'
+      delimiter: ''
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: '1'
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      not_found_message_allow: 0
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   promote:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 3
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 5
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 4
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -103,7 +125,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     settings:
       match_operator: CONTAINS
       size: 60

--- a/config/sync/core.entity_form_display.node.os2loop_external.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_external.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.os2loop_external.os2loop_shared_tags
     - node.type.os2loop_external
   module:
+    - autocomplete_deluxe
     - datetime
     - link
     - text
@@ -45,11 +46,18 @@ content:
     weight: 126
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_rev_date:
     weight: 127
@@ -61,21 +69,35 @@ content:
     weight: 124
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_tags:
     weight: 125
     settings:
+      limit: '10'
+      min_length: '0'
+      delimiter: ''
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: '1'
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      not_found_message_allow: 0
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.os2loop_post.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_post.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.os2loop_post.os2loop_shared_tags
     - node.type.os2loop_post
   module:
+    - autocomplete_deluxe
     - comment
     - datetime
     - file
@@ -52,11 +53,18 @@ content:
     weight: 9
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_rev_date:
     weight: 26
@@ -68,21 +76,35 @@ content:
     weight: 7
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
   os2loop_shared_tags:
     weight: 8
     settings:
+      limit: '10'
+      min_length: '0'
+      delimiter: ''
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: '1'
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      not_found_message_allow: 0
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
     third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
+    type: autocomplete_deluxe
     region: content
   promote:
     type: boolean_checkbox

--- a/config/sync/core.entity_form_display.node.os2loop_question.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_question.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.os2loop_question.os2loop_shared_tags
     - node.type.os2loop_question
   module:
+    - autocomplete_deluxe
     - comment
     - datetime
     - file
@@ -28,7 +29,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   os2loop_question_answers:
-    weight: 26
+    weight: 11
     settings: {  }
     third_party_settings: {  }
     type: comment_default
@@ -51,15 +52,22 @@ content:
   os2loop_shared_profession:
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
-    weight: 7
+    weight: 9
   os2loop_shared_rev_date:
-    weight: 27
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -67,23 +75,37 @@ content:
   os2loop_shared_subject:
     settings:
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: autocomplete_deluxe
     region: content
-    weight: 8
+    weight: 7
   os2loop_shared_tags:
     settings:
+      limit: '10'
+      min_length: '0'
+      delimiter: ''
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: '1'
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
+      not_found_message_allow: 0
       match_operator: CONTAINS
-      match_limit: 10
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
       size: 60
-      placeholder: ''
+      selection_handler: default
     third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
+    type: autocomplete_deluxe
     region: content
-    weight: 9
+    weight: 8
   promote:
     type: boolean_checkbox
     settings:

--- a/config/sync/core.entity_form_display.user.user.default.yml
+++ b/config/sync/core.entity_form_display.user.user.default.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.user.user.os2loop_user_professions
     - image.style.thumbnail
   module:
+    - autocomplete_deluxe
     - field_group
     - image
     - user
@@ -123,14 +124,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
   os2loop_user_areas_of_expertise:
-    type: entity_reference_autocomplete_tags
+    type: autocomplete_deluxe
     weight: 0
     region: content
     settings:
       match_operator: CONTAINS
-      match_limit: 10
       size: 60
-      placeholder: ''
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
   os2loop_user_biography:
     type: string_textarea
@@ -205,14 +213,21 @@ content:
       placeholder: ''
     third_party_settings: {  }
   os2loop_user_professions:
-    type: entity_reference_autocomplete_tags
+    type: autocomplete_deluxe
     weight: 0
     region: content
     settings:
       match_operator: CONTAINS
-      match_limit: 10
       size: 60
-      placeholder: ''
+      autocomplete_route_name: autocomplete_deluxe.autocomplete
+      selection_handler: default
+      limit: 10
+      min_length: 0
+      delimiter: ''
+      not_found_message_allow: false
+      not_found_message: 'The term ''@term'' will be added'
+      new_terms: false
+      no_empty_message: 'No terms could be found. Please type in order to add a new term.'
     third_party_settings: {  }
 hidden:
   language: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -1,4 +1,5 @@
 module:
+  autocomplete_deluxe: 0
   block: 0
   breakpoint: 0
   ckeditor: 0


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-832

Adds [Autocomplete deluxe](https://www.drupal.org/project/autocomplete_deluxe) to taxonomy fields.
Makes order of taxonomy fields consistent.
