### PR TITLE
LOOP-832: Collection documents ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ composer install --no-dev --optimize-autoloader
 vendor/bin/drush --yes site:install os2loop --existing-config
 ```
 
+You must also build the [OS2Loop
+theme](web/profiles/custom/os2loop/themes/os2loop_theme/README.md) assets; see
+[Building
+assets](web/profiles/custom/os2loop/themes/os2loop_theme/README.md#building-assets)
+for details.
+
 ### Development
 
 See [docs/development](docs/development/README.md) for details on development.

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "drupal/snowball_stemmer": "^2.0",
         "drupal/theme_switcher": "dev-8.x-1.x",
         "drupal/viewsreference": "^2.0",
-        "drush/drush": "^10.4"
+        "drush/drush": "^10.4",
+        "mikehaertl/phpwkhtmltopdf": "^2.5"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -154,6 +154,7 @@
         "drupal/coder": "^8.3",
         "drupal/core-dev": "^9.1",
         "friendsoftwig/twigcs": "^5.0",
-        "os2loop/os2loop_fixtures": "*"
+        "os2loop/os2loop_fixtures": "*",
+        "phpspec/prophecy-phpunit": "^2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "drupal/search_api_autocomplete": "^1.4",
         "drupal/snowball_stemmer": "^2.0",
         "drupal/theme_switcher": "dev-8.x-1.x",
+        "drupal/twig_tweak": "^3.0",
         "drupal/viewsreference": "^2.0",
         "drush/drush": "^10.4",
         "mikehaertl/phpwkhtmltopdf": "^2.5"

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "drupal/core-project-message": "^9.1",
         "drupal/core-recommended": "^9.1",
         "drupal/diff": "^1.0",
+        "drupal/entity_print": "^2.2",
         "drupal/facets": "^1.7",
         "drupal/field_group": "^3.1",
         "drupal/flag": "^4.0@beta",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0571fa9fcdc9090e54879293443db527",
+    "content-hash": "744d1555b7e8f1527dc29be966962455",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1144,43 +1144,6 @@
             "time": "2017-01-20T21:14:22+00:00"
         },
         {
-            "name": "dnoegel/php-xdg-base-dir",
-            "version": "v0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
-                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
-                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "XdgBaseDir\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "implementation of xdg base directory specification for php",
-            "support": {
-                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
-                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
-            },
-            "time": "2019-12-04T15:06:13+00:00"
-        },
-        {
             "name": "doctrine/annotations",
             "version": "1.11.1",
             "source": {
@@ -1417,6 +1380,78 @@
             },
             "abandoned": "roave/better-reflection",
             "time": "2020-10-27T21:46:55+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v0.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "db91d81866c69a42dad1d2926f61515a1e3f42c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/db91d81866c69a42dad1d2926f61515a1e3f42c5",
+                "reference": "db91d81866c69a42dad1d2926f61515a1e3f42c5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "phenx/php-font-lib": "^0.5.2",
+                "phenx/php-svg-lib": "^0.3.3",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                },
+                {
+                    "name": "Brian Sweeney",
+                    "email": "eclecticgeek@gmail.com"
+                },
+                {
+                    "name": "Gabriel Bull",
+                    "email": "me@gabrielbull.com"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/master"
+            },
+            "time": "2020-08-30T22:54:22+00:00"
         },
         {
             "name": "drupal/adminimal_theme",
@@ -2096,6 +2131,68 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/diff",
                 "issues": "https://www.drupal.org/project/issues/diff"
+            }
+        },
+        {
+            "name": "drupal/entity_print",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_print.git",
+                "reference": "8.x-2.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_print-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "5bd7671e2563a68925ab7f6ecd8dc8e8e396a0ea"
+            },
+            "require": {
+                "dompdf/dompdf": "~0.8.0",
+                "drupal/core": "^8 || ^9"
+            },
+            "suggest": {
+                "mikehaertl/phpwkhtmltopdf": "PhpWkhtmlToPdf provides the PHP library to use Wkhtmltopdf"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.2",
+                    "datestamp": "1592533892",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Dougherty",
+                    "homepage": "https://www.drupal.org/u/benjy"
+                },
+                {
+                    "name": "benjy",
+                    "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "pameeela",
+                    "homepage": "https://www.drupal.org/user/1431110"
+                }
+            ],
+            "description": "PDF print solution for any Drupal entity.",
+            "homepage": "http://drupal.org/project/entity_print",
+            "keywords": [
+                "PDF",
+                "drupal",
+                "print",
+                "web"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_print"
             }
         },
         {
@@ -2783,6 +2880,61 @@
                 "source": "http://cgit.drupalcode.org/theme_switcher"
             },
             "time": "2020-12-29T15:42:43+00:00"
+        },
+        {
+            "name": "drupal/twig_tweak",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/twig_tweak.git",
+                "reference": "3.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/twig_tweak-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "c8596addb06cbc67ad7914533c7e96e97ecbd54a"
+            },
+            "require": {
+                "drupal/core": "^9.0",
+                "ext-json": "*",
+                "php": ">=7.3",
+                "twig/twig": "^2.12"
+            },
+            "suggest": {
+                "symfony/var-dumper": "Better dump() function for debugging Twig variables"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.0",
+                    "datestamp": "1608096220",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Chi",
+                    "homepage": "https://www.drupal.org/user/556138"
+                }
+            ],
+            "description": "A Twig extension with some useful functions and filters for Drupal development.",
+            "homepage": "https://www.drupal.org/project/twig_tweak",
+            "keywords": [
+                "Drupal",
+                "Twig"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/twig_tweak",
+                "issues": "https://www.drupal.org/project/issues/twig_tweak"
+            }
         },
         {
             "name": "drupal/viewsreference",
@@ -3991,6 +4143,147 @@
             "time": "2020-10-01T13:52:52+00:00"
         },
         {
+            "name": "mikehaertl/php-shellcommand",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikehaertl/php-shellcommand.git",
+                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikehaertl/php-shellcommand/zipball/3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
+                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">4.0 <=9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "mikehaertl\\shellcommand\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Härtl",
+                    "email": "haertl.mike@gmail.com"
+                }
+            ],
+            "description": "An object oriented interface to shell commands",
+            "keywords": [
+                "shell"
+            ],
+            "support": {
+                "issues": "https://github.com/mikehaertl/php-shellcommand/issues",
+                "source": "https://github.com/mikehaertl/php-shellcommand/tree/1.6.4"
+            },
+            "time": "2021-03-17T06:54:33+00:00"
+        },
+        {
+            "name": "mikehaertl/php-tmpfile",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikehaertl/php-tmpfile.git",
+                "reference": "70a5b70b17bc0d9666388e6a551ecc93d0b40a10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikehaertl/php-tmpfile/zipball/70a5b70b17bc0d9666388e6a551ecc93d0b40a10",
+                "reference": "70a5b70b17bc0d9666388e6a551ecc93d0b40a10",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php": ">=5.3.0",
+                "phpunit/phpunit": ">4.0 <=9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "mikehaertl\\tmp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Härtl",
+                    "email": "haertl.mike@gmail.com"
+                }
+            ],
+            "description": "A convenience class for temporary files",
+            "keywords": [
+                "files"
+            ],
+            "support": {
+                "issues": "https://github.com/mikehaertl/php-tmpfile/issues",
+                "source": "https://github.com/mikehaertl/php-tmpfile/tree/1.2.1"
+            },
+            "time": "2021-03-01T18:26:25+00:00"
+        },
+        {
+            "name": "mikehaertl/phpwkhtmltopdf",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikehaertl/phpwkhtmltopdf.git",
+                "reference": "17ee71341591415d942774eda2c98d8ba7ea9e90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikehaertl/phpwkhtmltopdf/zipball/17ee71341591415d942774eda2c98d8ba7ea9e90",
+                "reference": "17ee71341591415d942774eda2c98d8ba7ea9e90",
+                "shasum": ""
+            },
+            "require": {
+                "mikehaertl/php-shellcommand": "^1.5.0",
+                "mikehaertl/php-tmpfile": "^1.2.1",
+                "php": ">=5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">4.0 <9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "mikehaertl\\wkhtmlto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Haertl",
+                    "email": "haertl.mike@gmail.com"
+                }
+            ],
+            "description": "A slim PHP wrapper around wkhtmltopdf with an easy to use and clean OOP interface",
+            "homepage": "http://mikehaertl.github.com/phpwkhtmltopdf/",
+            "keywords": [
+                "pdf",
+                "wkhtmltoimage",
+                "wkhtmltopdf"
+            ],
+            "support": {
+                "issues": "https://github.com/mikehaertl/phpwkhtmltopdf/issues",
+                "source": "https://github.com/mikehaertl/phpwkhtmltopdf/tree/2.5.0"
+            },
+            "time": "2021-03-01T19:41:06+00:00"
+        },
+        {
             "name": "mkalkbrenner/php-htmldiff-advanced",
             "version": "0.0.8",
             "source": {
@@ -4326,6 +4619,91 @@
             "time": "2019-12-10T10:24:42+00:00"
         },
         {
+            "name": "phenx/php-font-lib",
+            "version": "0.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PhenX/php-font-lib.git",
+                "reference": "ca6ad461f032145fff5971b5985e5af9e7fa88d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PhenX/php-font-lib/zipball/ca6ad461f032145fff5971b5985e5af9e7fa88d8",
+                "reference": "ca6ad461f032145fff5971b5985e5af9e7fa88d8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5 || ^6 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/PhenX/php-font-lib",
+            "support": {
+                "issues": "https://github.com/PhenX/php-font-lib/issues",
+                "source": "https://github.com/PhenX/php-font-lib/tree/0.5.2"
+            },
+            "time": "2020-03-08T15:31:32+00:00"
+        },
+        {
+            "name": "phenx/php-svg-lib",
+            "version": "v0.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PhenX/php-svg-lib.git",
+                "reference": "5fa61b65e612ce1ae15f69b3d223cb14ecc60e32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PhenX/php-svg-lib/zipball/5fa61b65e612ce1ae15f69b3d223cb14ecc60e32",
+                "reference": "5fa61b65e612ce1ae15f69b3d223cb14ecc60e32",
+                "shasum": ""
+            },
+            "require": {
+                "sabberworm/php-css-parser": "^8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.5|^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Ménager",
+                    "email": "fabien.menager@gmail.com"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/PhenX/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/PhenX/php-svg-lib/issues",
+                "source": "https://github.com/PhenX/php-svg-lib/tree/master"
+            },
+            "time": "2019-09-11T20:02:13+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -4538,20 +4916,19 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.10.7",
+            "version": "v0.10.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "a395af46999a12006213c0c8346c9445eb31640c"
+                "reference": "e4573f47750dd6c92dca5aee543fa77513cbd8d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/a395af46999a12006213c0c8346c9445eb31640c",
-                "reference": "a395af46999a12006213c0c8346c9445eb31640c",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/e4573f47750dd6c92dca5aee543fa77513cbd8d3",
+                "reference": "e4573f47750dd6c92dca5aee543fa77513cbd8d3",
                 "shasum": ""
             },
             "require": {
-                "dnoegel/php-xdg-base-dir": "0.1.*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "nikic/php-parser": "~4.0|~3.0|~2.0|~1.3",
@@ -4608,9 +4985,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.10.7"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.10.8"
             },
-            "time": "2021-03-14T02:14:56+00:00"
+            "time": "2021-04-10T16:23:39+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4655,6 +5032,55 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "8.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
+                "reference": "d217848e1396ef962fb1997cf3e2421acba7f796"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/d217848e1396ef962fb1997cf3e2421acba7f796",
+                "reference": "d217848e1396ef962fb1997cf3e2421acba7f796",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "codacy/coverage": "^1.4",
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sabberworm\\CSS": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "http://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/sabberworm/PHP-CSS-Parser/issues",
+                "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/8.3.1"
+            },
+            "time": "2020-06-01T09:10:00+00:00"
         },
         {
             "name": "stack/builder",
@@ -9048,7 +9474,7 @@
         },
         {
             "name": "os2loop/os2loop_fixtures",
-            "version": "dev-feature/LOOP-832-taxonomies",
+            "version": "dev-feature/LOOP-832-colletion-documents-ui",
             "dist": {
                 "type": "path",
                 "url": "web/profiles/custom/os2loop/modules/os2loop_fixtures",
@@ -9408,6 +9834,58 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
             "time": "2021-03-17T13:42:18+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:33:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/sync/core.entity_view_display.comment.os2loop_post_comment.default.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_post_comment.default.yml
@@ -35,4 +35,7 @@ content:
     type: text_default
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.comment.os2loop_question_answer.default.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_question_answer.default.yml
@@ -35,4 +35,7 @@ content:
     type: text_default
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_collection.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_collection.default.yml
@@ -58,4 +58,7 @@ content:
     type: entity_reference_label
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_collection.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_collection.os2loop_search_db_search_autocomplete.yml
@@ -30,6 +30,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_documents_dc_content: true
   os2loop_shared_profession: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_collection.pdf.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_collection.pdf.yml
@@ -1,8 +1,9 @@
-uuid: 6760a242-fd8f-4daf-af9b-f05dd5448ac3
+uuid: 6bc55882-9e67-48b8-bb60-e500291c4fd6
 langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.pdf
     - field.field.node.os2loop_documents_collection.os2loop_documents_dc_content
     - field.field.node.os2loop_documents_collection.os2loop_shared_profession
     - field.field.node.os2loop_documents_collection.os2loop_shared_subject
@@ -11,13 +12,13 @@ dependencies:
   module:
     - text
     - user
-id: node.os2loop_documents_collection.default
+id: node.os2loop_documents_collection.pdf
 targetEntityType: node
 bundle: os2loop_documents_collection
-mode: default
+mode: pdf
 content:
   flag_os2loop_favourite:
-    weight: 10
+    weight: 0
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.os2loop_documents_collection.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_collection.search_result.yml
@@ -30,6 +30,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_documents_dc_content: true
   os2loop_shared_profession: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_collection.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_collection.teaser.yml
@@ -27,6 +27,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_documents_dc_content: true
   os2loop_shared_profession: true
   os2loop_shared_subject: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.default.yml
@@ -78,4 +78,7 @@ content:
     type: entity_reference_label
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.os2loop_search_db_search_autocomplete.yml
@@ -31,6 +31,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_documents_document_autho: true
   os2loop_documents_document_body: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.pdf.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.pdf.yml
@@ -1,0 +1,76 @@
+uuid: baca6129-9458-415f-b651-c7197a86496c
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.pdf
+    - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
+    - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
+    - field.field.node.os2loop_documents_document.os2loop_shared_profession
+    - field.field.node.os2loop_documents_document.os2loop_shared_subject
+    - field.field.node.os2loop_documents_document.os2loop_shared_tags
+    - node.type.os2loop_documents_document
+  module:
+    - entity_reference_revisions
+    - user
+id: node.os2loop_documents_document.pdf
+targetEntityType: node
+bundle: os2loop_documents_document
+mode: pdf
+content:
+  flag_os2loop_favourite:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  os2loop_documents_document_autho:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  os2loop_documents_document_conte:
+    type: entity_reference_revisions_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  os2loop_shared_profession:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  os2loop_shared_subject:
+    weight: 4
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  os2loop_shared_tags:
+    weight: 5
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.search_result.yml
@@ -31,6 +31,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_documents_document_autho: true
   os2loop_documents_document_body: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.teaser.yml
@@ -29,6 +29,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_documents_document_autho: true
   os2loop_documents_document_body: true
   os2loop_documents_document_conte: true

--- a/config/sync/core.entity_view_display.node.os2loop_external.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_external.default.yml
@@ -78,4 +78,7 @@ content:
     type: entity_reference_label
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_external.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_external.os2loop_search_db_search_autocomplete.yml
@@ -32,6 +32,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_external_descripti: true
   os2loop_external_url: true

--- a/config/sync/core.entity_view_display.node.os2loop_external.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_external.search_result.yml
@@ -32,6 +32,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_external_descripti: true
   os2loop_external_url: true

--- a/config/sync/core.entity_view_display.node.os2loop_external.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_external.teaser.yml
@@ -24,6 +24,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_external_descripti: true
   os2loop_external_url: true
   os2loop_shared_profession: true

--- a/config/sync/core.entity_view_display.node.os2loop_page.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_page.default.yml
@@ -37,4 +37,7 @@ content:
     type: image
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_page.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_page.os2loop_search_db_search_autocomplete.yml
@@ -20,6 +20,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_page_content: true
   os2loop_page_image: true

--- a/config/sync/core.entity_view_display.node.os2loop_page.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_page.search_result.yml
@@ -20,6 +20,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_page_content: true
   os2loop_page_image: true

--- a/config/sync/core.entity_view_display.node.os2loop_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_page.teaser.yml
@@ -20,6 +20,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_page_content: true
   os2loop_page_image: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_post.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_post.default.yml
@@ -91,4 +91,7 @@ content:
     type: entity_reference_label
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_post.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_post.os2loop_search_db_search_autocomplete.yml
@@ -33,6 +33,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_post_comments: true
   os2loop_post_content: true

--- a/config/sync/core.entity_view_display.node.os2loop_post.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_post.search_result.yml
@@ -33,6 +33,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_post_comments: true
   os2loop_post_content: true

--- a/config/sync/core.entity_view_display.node.os2loop_post.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_post.teaser.yml
@@ -30,6 +30,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_post_comments: true
   os2loop_post_content: true
   os2loop_post_file: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.default.yml
@@ -91,4 +91,7 @@ content:
     region: content
     weight: 4
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.os2loop_search_db_search_autocomplete.yml
@@ -33,6 +33,9 @@ content:
     region: content
     weight: 1
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_question_answers: true
   os2loop_question_content: true
   os2loop_question_file: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.search_result.yml
@@ -33,6 +33,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   links: true
   os2loop_question_answers: true
   os2loop_question_content: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.teaser.yml
@@ -30,6 +30,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_question_answers: true
   os2loop_question_content: true
   os2loop_question_file: true

--- a/config/sync/core.entity_view_display.node.os2loop_section_page.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_section_page.default.yml
@@ -28,4 +28,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_section_page.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_section_page.teaser.yml
@@ -19,5 +19,8 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_section_page_paragraph: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_highlighted_co.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_highlighted_co.default.yml
@@ -29,4 +29,7 @@ content:
     type: string
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_highlighted_co.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_highlighted_co.default.yml
@@ -15,14 +15,14 @@ mode: default
 content:
   os2loop_documents_hc_content:
     weight: 1
-    label: visually_hidden
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   os2loop_documents_hc_title:
     weight: 0
-    label: visually_hidden
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_step.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_step.default.yml
@@ -18,7 +18,7 @@ mode: default
 content:
   os2loop_documents_step_image:
     weight: 1
-    label: visually_hidden
+    label: hidden
     settings:
       image_style: ''
       image_link: ''
@@ -27,7 +27,7 @@ content:
     region: content
   os2loop_documents_step_text:
     weight: 0
-    label: visually_hidden
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
@@ -35,7 +35,7 @@ content:
   os2loop_documents_steps:
     type: entity_reference_revisions_entity_view
     weight: 2
-    label: visually_hidden
+    label: hidden
     settings:
       view_mode: default
       link: ''

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_step.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_step.default.yml
@@ -42,4 +42,7 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_step_by_step.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_step_by_step.default.yml
@@ -31,4 +31,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_step_by_step.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_step_by_step.default.yml
@@ -16,14 +16,14 @@ mode: default
 content:
   os2loop_documents_description:
     weight: 0
-    label: visually_hidden
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
     region: content
   os2loop_documents_steps:
     weight: 2
-    label: visually_hidden
+    label: hidden
     settings:
       view_mode: default
       link: ''

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_text_and_image.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_text_and_image.default.yml
@@ -31,4 +31,7 @@ content:
     type: text_default
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.paragraph.os2loop_documents_text_and_image.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_documents_text_and_image.default.yml
@@ -16,7 +16,7 @@ mode: default
 content:
   os2loop_documents_tai_image:
     weight: 1
-    label: visually_hidden
+    label: hidden
     settings:
       image_style: ''
       image_link: ''
@@ -25,7 +25,7 @@ content:
     region: content
   os2loop_documents_tai_text:
     weight: 0
-    label: visually_hidden
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default

--- a/config/sync/core.entity_view_display.paragraph.os2loop_section_page_views_refer.default.yml
+++ b/config/sync/core.entity_view_display.paragraph.os2loop_section_page_views_refer.default.yml
@@ -40,4 +40,7 @@ content:
     type: text_default
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.user.user.default.yml
+++ b/config/sync/core.entity_view_display.user.user.default.yml
@@ -28,6 +28,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  entity_print_view_epub: true
+  entity_print_view_pdf: true
+  entity_print_view_word_docx: true
   os2loop_user_address: true
   os2loop_user_areas_of_expertise: true
   os2loop_user_biography: true

--- a/config/sync/core.entity_view_mode.node.pdf.yml
+++ b/config/sync/core.entity_view_mode.node.pdf.yml
@@ -1,0 +1,10 @@
+uuid: f0641e4e-563b-4e43-a048-321cdb4fd404
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.pdf
+label: PDF
+targetEntityType: node
+cache: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -8,6 +8,7 @@ module:
   dblog: 0
   dynamic_page_cache: 0
   editor: 0
+  entity_print: 0
   entity_reference_revisions: 0
   facets: 0
   field: 0

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -28,6 +28,7 @@ module:
   os2loop_post: 0
   os2loop_question: 0
   os2loop_search_db: 0
+  os2loop_section_page: 0
   os2loop_shared: 0
   os2loop_taxonomy: 0
   os2loop_upvote: 0
@@ -44,6 +45,7 @@ module:
   text: 0
   theme_switcher: 0
   toolbar: 0
+  twig_tweak: 0
   update: 0
   user: 0
   views: 0

--- a/config/sync/entity_print.print_engine.dompdf.yml
+++ b/config/sync/entity_print.print_engine.dompdf.yml
@@ -1,0 +1,16 @@
+uuid: 088e73f1-db24-4f8e-8084-38d772ea2bca
+langcode: en
+status: true
+dependencies: {  }
+id: dompdf
+settings:
+  orientation: portrait
+  default_paper_size: a4
+  username: ''
+  password: ''
+  enable_html5_parser: true
+  disable_log: 0
+  enable_remote: true
+  cafile: ''
+  verify_peer: true
+  verify_peer_name: true

--- a/config/sync/entity_print.print_engine.phpwkhtmltopdf.yml
+++ b/config/sync/entity_print.print_engine.phpwkhtmltopdf.yml
@@ -1,0 +1,18 @@
+uuid: d485098c-9211-4455-bfe1-2510e099fb2a
+langcode: en
+status: true
+dependencies: {  }
+id: phpwkhtmltopdf
+settings:
+  orientation: portrait
+  default_paper_size: a4
+  username: ''
+  password: ''
+  binary_location: /usr/local/bin/wkhtmltopdf
+  zoom: '1'
+  toc_generate: false
+  toc_enable_back_links: false
+  toc_disable_dotted_lines: false
+  toc_disable_links: false
+  viewport_size: _none
+  remove_pdf_margins: false

--- a/config/sync/entity_print.settings.yml
+++ b/config/sync/entity_print.settings.yml
@@ -1,0 +1,8 @@
+default_css: true
+force_download: true
+print_engines:
+  pdf_engine: dompdf
+  epub_engine: ''
+  word_docx_engine: ''
+_core:
+  default_config_hash: nF3sn8D7n0S0cxMK-kk9HmtudLA5iIm0EXJo7xJQQRY

--- a/config/sync/entity_print.settings.yml
+++ b/config/sync/entity_print.settings.yml
@@ -1,7 +1,7 @@
 default_css: true
 force_download: true
 print_engines:
-  pdf_engine: dompdf
+  pdf_engine: phpwkhtmltopdf
   epub_engine: ''
   word_docx_engine: ''
 _core:

--- a/config/sync/system.action.entity_print_pdf_download_action.yml
+++ b/config/sync/system.action.entity_print_pdf_download_action.yml
@@ -1,0 +1,14 @@
+uuid: 712c9136-7037-48a8-ad79-d7de23343a2d
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_print
+_core:
+  default_config_hash: '-1tKqx12tWtYmD0zG5XJIem7pCyfpZ3zyS9BNWbjlFk'
+id: entity_print_pdf_download_action
+label: 'Download PDF'
+type: node
+plugin: entity_print_download_action
+configuration:
+  export_type: pdf

--- a/docs/development/Testing.md
+++ b/docs/development/Testing.md
@@ -14,6 +14,33 @@ To add Cypress tests to a module, `os2loop_page`, say, add a sub-module called
 
 ```sh
 web/profiles/custom/os2loop/modules/os2loop_page
-├── modules
-│   └── os2loop_page_tests_cypress
+└── modules
+    ├── os2loop_page_tests
+    └── os2loop_page_tests_cypress
+```
+
+## Unit tests
+
+```sh
+cd web
+php core/scripts/run-tests.sh --sqlite /tmp/test.sqlite os2loop_tests
+```
+
+```sh
+vendor/bin/phpunit --configuration web/core
+```
+
+## Running tests with the symfony binary
+
+To run tests with the symfony binary we need a to patch `run-tests.sh` (cf. <https://www.drupal.org/project/drupal/issues/2748883#comment-12102000>):
+
+```sh
+cd web
+curl https://www.drupal.org/files/issues/use_the_php_binary-2748883-32.patch | patch --strip=1
+```
+
+Then run tests with
+
+```sh
+symfony php core/scripts/run-tests.sh --php 'symfony php' --sqlite /tmp/test.sqlite os2loop_tests
 ```

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/README.md
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/README.md
@@ -8,6 +8,22 @@ Documents and document collections.
 as content migrated from the old OS2Loop system. The body field is only
 available on legacy documents.
 
+## Printing to pdf
+
+We use [`phpwkhtmltopdf`](https://github.com/mikehaertl/phpwkhtmltopdf) for
+printing documents and collections as PDF files.
+
+In order to make it work you need a working installation of wkhtmltopdf 0.12.6
+(see <https://github.com/mikehaertl/phpwkhtmltopdf#installation-of-wkhtmltopdf>)
+available as `/usr/local/bin/wkhtmltopdf`.
+
+If need be, you can override the path to the `wkhtmltopdf` binary in
+`settings.local.php`, e.g.:
+
+```php
+$config['entity_print.print_engine.phpwkhtmltopdf']['settings']['binary_location'] = '/opt/wkhtmltopdf/wkhtmltopdf';
+```
+
 ## Fixtures
 
 ```sh

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/README.md
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/README.md
@@ -10,11 +10,14 @@ available on legacy documents.
 
 ## Printing to pdf
 
-We use [`phpwkhtmltopdf`](https://github.com/mikehaertl/phpwkhtmltopdf) for
-printing documents and collections as PDF files.
+We use [Entity Print](https://www.drupal.org/project/entity_print) for
+printing documents and collections, i.e converting them to PDF.
 
-In order to make it work you need a working installation of wkhtmltopdf 0.12.6
-(see <https://github.com/mikehaertl/phpwkhtmltopdf#installation-of-wkhtmltopdf>)
+Entity Print is configured to use
+[`phpwkhtmltopdf`](https://github.com/mikehaertl/phpwkhtmltopdf) for converting
+HTML to PDF, and in order to make this work you need a working installation of
+wkhtmltopdf 0.12.6 (see
+<https://github.com/mikehaertl/phpwkhtmltopdf#installation-of-wkhtmltopdf>)
 available as `/usr/local/bin/wkhtmltopdf`.
 
 If need be, you can override the path to the `wkhtmltopdf` binary in
@@ -23,6 +26,11 @@ If need be, you can override the path to the `wkhtmltopdf` binary in
 ```php
 $config['entity_print.print_engine.phpwkhtmltopdf']['settings']['binary_location'] = '/opt/wkhtmltopdf/wkhtmltopdf';
 ```
+
+### Debugging entity print input
+
+See <https://www.drupal.org/node/2706755#debugging> for help on debugging the
+templates and resulting HTML that will be used to generate the final PDF.
 
 ## Fixtures
 

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/os2loop_documents_fixtures.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/os2loop_documents_fixtures.services.yml
@@ -11,5 +11,6 @@ services:
 
   os2loop_documents_fixtures.collection_fixture:
     class: Drupal\os2loop_documents_fixtures\Fixture\CollectionFixture
+    arguments: ['@os2loop_documents.collection_helper']
     tags:
       - { name: content_fixture }

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/src/Fixture/CollectionFixture.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/src/Fixture/CollectionFixture.php
@@ -6,6 +6,7 @@ use Drupal\content_fixtures\Fixture\AbstractFixture;
 use Drupal\content_fixtures\Fixture\DependentFixtureInterface;
 use Drupal\content_fixtures\Fixture\FixtureGroupInterface;
 use Drupal\node\Entity\Node;
+use Drupal\os2loop_documents\Helper\CollectionHelper;
 use Drupal\os2loop_taxonomy_fixtures\Fixture\ProfessionFixture;
 use Drupal\os2loop_taxonomy_fixtures\Fixture\SubjectFixture;
 use Drupal\os2loop_taxonomy_fixtures\Fixture\TagFixture;
@@ -16,12 +17,26 @@ use Drupal\os2loop_taxonomy_fixtures\Fixture\TagFixture;
  * @package Drupal\os2loop_documents_fixtures\Fixture
  */
 class CollectionFixture extends AbstractFixture implements DependentFixtureInterface, FixtureGroupInterface {
+  /**
+   * The collection helper.
+   *
+   * @var \Drupal\os2loop_documents\Helper\CollectionHelper
+   */
+  private $collectionHelper;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(CollectionHelper $collectionHelper) {
+    $this->collectionHelper = $collectionHelper;
+  }
 
   /**
    * {@inheritdoc}
    */
   public function load() {
-    $document = Node::create([
+    $collection = Node::create([
+      'nid' => 87,
       'type' => 'os2loop_documents_collection',
       'title' => 'The first collection',
       'os2loop_documents_dc_content' => [
@@ -41,7 +56,37 @@ BODY,
         'target_id' => $this->getReference('os2loop_profession:Andet')->id(),
       ],
     ]);
-    $document->save();
+    $collection->save();
+    $this->collectionHelper->addDocument($collection, $this->getReference('os2loop_documents_document:Aaa'));
+    $this->collectionHelper->addDocument($collection, $this->getReference('os2loop_documents_document:Bbb'), $this->getReference('os2loop_documents_document:Aaa'));
+    $this->collectionHelper->addDocument($collection, $this->getReference('os2loop_documents_document:Ccc'));
+    $this->collectionHelper->addDocument($collection, $this->getReference('os2loop_documents_document:Ddd'), $this->getReference('os2loop_documents_document:Ccc'));
+    $this->collectionHelper->addDocument($collection, $this->getReference('os2loop_documents_document:Eee'), $this->getReference('os2loop_documents_document:Ddd'));
+
+    $collection = Node::create([
+      'nid' => 42,
+      'type' => 'os2loop_documents_collection',
+      'title' => 'Another collection',
+      'os2loop_documents_dc_content' => [
+        'value' => <<<'BODY'
+<p>This collection shares a document with <a href="/node/87">The first collection</a>.</p>
+BODY,
+        'format' => 'os2loop_documents_rich_text',
+      ],
+      'os2loop_shared_subject' => [
+        'target_id' => $this->getReference('os2loop_subject:Diverse')->id(),
+      ],
+      'os2loop_shared_tags' => [
+        ['target_id' => $this->getReference('os2loop_tag:test')->id()],
+        ['target_id' => $this->getReference('os2loop_tag:Udredning')->id()],
+      ],
+      'os2loop_shared_profession' => [
+        'target_id' => $this->getReference('os2loop_profession:Andet')->id(),
+      ],
+    ]);
+    $collection->save();
+
+    $this->collectionHelper->addDocument($collection, $this->getReference('os2loop_documents_document:Aaa'));
   }
 
   /**

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/src/Fixture/DocumentFixture.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/src/Fixture/DocumentFixture.php
@@ -165,6 +165,26 @@ BODY,
     $document->get('os2loop_documents_document_conte')->appendItem($paragraph);
 
     $document->save();
+
+    foreach (['Aaa', 'Bbb', 'Ccc', 'Ddd', 'Eee', 'Fff'] as $title) {
+      $document = Node::create([
+        'type' => 'os2loop_documents_document',
+        'title' => $title,
+        'os2loop_documents_document_autho' => 'Document Author',
+        'os2loop_shared_subject' => [
+          'target_id' => $this->getReference('os2loop_subject:Diverse')->id(),
+        ],
+        'os2loop_shared_tags' => [
+          ['target_id' => $this->getReference('os2loop_tag:test')->id()],
+          ['target_id' => $this->getReference('os2loop_tag:Udredning')->id()],
+        ],
+        'os2loop_shared_profession' => [
+          'target_id' => $this->getReference('os2loop_profession:Andet')->id(),
+        ],
+      ]);
+      $this->setReference($document->getType() . ':' . $document->getTitle(), $document);
+      $document->save();
+    }
   }
 
   /**

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/src/Fixture/DocumentFixture.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_fixtures/src/Fixture/DocumentFixture.php
@@ -182,6 +182,18 @@ BODY,
           'target_id' => $this->getReference('os2loop_profession:Andet')->id(),
         ],
       ]);
+
+      $paragraph = Paragraph::create([
+        'type' => 'os2loop_documents_highlighted_co',
+        'os2loop_documents_hc_title' => sprintf('Important note on %s', $document->getTitle()),
+        'os2loop_documents_hc_content' => [
+          'value' => sprintf('<p>This is the content of %s</p>', $document->getTitle()),
+          'format' => 'os2loop_documents_rich_text',
+        ],
+      ]);
+      $paragraph->save();
+      $document->get('os2loop_documents_document_conte')->appendItem($paragraph);
+
       $this->setReference($document->getType() . ':' . $document->getTitle(), $document);
       $document->save();
     }

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_tests/os2loop_documents_tests.info.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_tests/os2loop_documents_tests.info.yml
@@ -1,0 +1,10 @@
+name: 'OS2Loop Documents test'
+type: module
+description: 'OS2Loop Documents tests'
+# Used only for development and testing.
+hidden: true
+core_version_requirement: ^9
+package: OS2Loop
+# version: VERSION
+dependencies:
+  - os2loop_documents

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_tests/tests/src/Kernel/CollectionHelperTest.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/modules/os2loop_documents_tests/tests/src/Kernel/CollectionHelperTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\os2loop_documents_tests\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\os2loop_documents\Entity\DocumentCollectionItem;
+use Drupal\os2loop_documents\Helper\CollectionHelper;
+
+/**
+ * Collection helper test.
+ *
+ * @group os2loop_tests
+ * @group os2loop_documents_tests
+ */
+class CollectionHelperTest extends KernelTestBase {
+  /**
+   * The collection helper.
+   *
+   * @var \Drupal\os2loop_documents\Helper\CollectionHelper
+   */
+  private $collectionHelper;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'os2loop_documents',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->collectionHelper = \Drupal::service(CollectionHelper::class);
+  }
+
+  /**
+   * Test build tree.
+   *
+   * @dataProvider buildTreeDataProvider
+   */
+  public function testBuildTree(array $items, array $expected) {
+    $actual = $this->collectionHelper->buildTree($items);
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * Data provider.
+   *
+   * @return array
+   *   List of [$items, $expected].
+   */
+  public function buildTreeDataProvider(): array {
+    return [
+
+      [
+        [],
+        [],
+      ],
+
+      [
+        [
+          DocumentCollectionItem::create([
+            'id' => 1,
+          ]),
+        ],
+        [],
+      ],
+
+    ];
+  }
+
+}

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.module
@@ -5,6 +5,7 @@
  * Code for the Loop documents feature.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -31,4 +32,18 @@ function os2loop_documents_form_node_form_alter(array &$form, FormStateInterface
   // @todo We should use hook_event_dispatcher for this
   // https://www.drupal.org/project/hook_event_dispatcher/issues/3199174
   \Drupal::service('os2loop_documents.form_helper')->alterForm($form, $form_state, $form_id);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function os2loop_documents_node_update(EntityInterface $entity) {
+  \Drupal::service('os2loop_documents.node_helper')->updateNode($entity);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function os2loop_documents_preprocess_node(array &$variables) {
+  \Drupal::service('os2loop_documents.node_helper')->preprocessNode($variables);
 }

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.services.yml
@@ -19,3 +19,4 @@ services:
     arguments:
       - '@os2loop_documents.collection_helper'
       - '@request_stack'
+      - '@cache_tags.invalidator'

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.services.yml
@@ -1,3 +1,18 @@
 services:
+  os2loop_documents.collection_helper:
+    class: Drupal\os2loop_documents\Helper\CollectionHelper
+
   os2loop_documents.form_helper:
     class: Drupal\os2loop_documents\Helper\FormHelper
+    arguments:
+      - '@os2loop_documents.collection_helper'
+      - '@renderer'
+      - '@main_content_renderer.ajax'
+      - '@request_stack'
+      - '@current_route_match'
+      - '@messenger'
+
+  os2loop_documents.node_helper:
+    class: Drupal\os2loop_documents\Helper\NodeHelper
+    arguments:
+      - '@os2loop_documents.collection_helper'

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/os2loop_documents.services.yml
@@ -1,6 +1,8 @@
 services:
   os2loop_documents.collection_helper:
     class: Drupal\os2loop_documents\Helper\CollectionHelper
+    arguments:
+      - '@entity_type.manager'
 
   os2loop_documents.form_helper:
     class: Drupal\os2loop_documents\Helper\FormHelper
@@ -16,3 +18,4 @@ services:
     class: Drupal\os2loop_documents\Helper\NodeHelper
     arguments:
       - '@os2loop_documents.collection_helper'
+      - '@request_stack'

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Entity/DocumentCollectionItem.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Entity/DocumentCollectionItem.php
@@ -24,7 +24,8 @@ use Drupal\node\NodeInterface;
  * )
  *
  * @method DocumentCollectionItem create
- * @property \Drupal\Core\Field\FieldItemList parent_id
+ * @property \Drupal\Core\Field\FieldItemList collection_id
+ * @property \Drupal\Core\Field\FieldItemList parent_document_id
  * @property \Drupal\Core\Field\FieldItemList document_id
  * @property \Drupal\Core\Field\FieldItemList weight
  */
@@ -117,7 +118,7 @@ class DocumentCollectionItem extends ContentEntityBase implements ContentEntityI
       ->setDescription(t('The ID of the Document node.'))
       ->setRequired(TRUE);
 
-    $fields['parent_id'] = BaseFieldDefinition::create('integer')
+    $fields['parent_document_id'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Parent document ID'))
       ->setDescription(t('The ID of the parent Document node.'));
 

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Entity/DocumentCollectionItem.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Entity/DocumentCollectionItem.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 
 /**

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Entity/DocumentCollectionItem.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Entity/DocumentCollectionItem.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Drupal\os2loop_documents\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\node\NodeInterface;
+
+/**
+ * Defines the document collection item.
+ *
+ * @ContentEntityType(
+ *   id = "os2loop_document_collection_item",
+ *   label = @Translation("Document collection item"),
+ *   base_table = "os2loop_documents_collection_item",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "uuid" = "uuid",
+ *     "collection_id" = "collection_id",
+ *     "document_id" = "document_id",
+ *   },
+ * )
+ *
+ * @method DocumentCollectionItem create
+ * @property \Drupal\Core\Field\FieldItemList parent_id
+ * @property \Drupal\Core\Field\FieldItemList document_id
+ * @property \Drupal\Core\Field\FieldItemList weight
+ */
+class DocumentCollectionItem extends ContentEntityBase implements ContentEntityInterface {
+  /**
+   * The depth in tree.
+   *
+   * @var int
+   */
+  public $depth = 0;
+
+  /**
+   * The document if loaded.
+   *
+   * @var null|\Drupal\node\NodeInterface
+   */
+  public $document;
+
+  /**
+   * The children if loaded.
+   *
+   * @var \Drupal\node\NodeInterface[]
+   */
+  public $children = [];
+
+  /**
+   * Set collection.
+   *
+   * @param \Drupal\node\NodeInterface $collection
+   *   The collection.
+   *
+   * @return DocumentCollectionItem
+   *   The item.
+   */
+  public function setCollection(NodeInterface $collection): self {
+    return $this->set('collection_id', $collection->id());
+  }
+
+  /**
+   * Get collection.
+   */
+  public function getCollection(): NodeInterface {
+    return Node::load($this->get('collection_id')->value);
+  }
+
+  /**
+   * Set document.
+   *
+   * @param \Drupal\node\NodeInterface $document
+   *   The document.
+   *
+   * @return DocumentDocumentItem
+   *   The item.
+   */
+  public function setDocument(NodeInterface $document): self {
+    return $this->set('document_id', $document->id());
+  }
+
+  /**
+   * Get document.
+   */
+  public function getDocument(): NodeInterface {
+    return Node::load($this->get('document_id')->value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entityType) {
+    // Standard field, used as unique if primary index.
+    $fields['id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('ID'))
+      ->setDescription(t('The ID of the Contact entity.'))
+      ->setReadOnly(TRUE);
+
+    // Standard field, unique outside of the scope of the current project.
+    $fields['uuid'] = BaseFieldDefinition::create('uuid')
+      ->setLabel(t('UUID'))
+      ->setDescription(t('The UUID of the Advertiser entity.'))
+      ->setReadOnly(TRUE);
+
+    $fields['collection_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Collection ID'))
+      ->setDescription(t('The ID of the Collection node.'))
+      ->setRequired(TRUE)
+      ->setReadOnly(TRUE);
+
+    $fields['document_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Document ID'))
+      ->setDescription(t('The ID of the Document node.'))
+      ->setRequired(TRUE);
+
+    $fields['parent_id'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Parent document ID'))
+      ->setDescription(t('The ID of the parent Document node.'));
+
+    $fields['weight'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Weight'))
+      ->setDescription(t('The weight.'))
+      ->setRequired(TRUE);
+
+    return $fields;
+  }
+
+}

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/CollectionHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/CollectionHelper.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Drupal\os2loop_documents\Helper;
+
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Drupal\os2loop_documents\Entity\DocumentCollectionItem;
+
+/**
+ * Collection helper.
+ */
+class CollectionHelper {
+
+  /**
+   * Load collection items from database.
+   *
+   * @param \Drupal\node\Entity\NodeInterface $collection
+   *   The collection.
+   *
+   * @return \Drupal\os2loop_documents\Entity\DocumentCollectionItem[]
+   *   The collection items.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function loadCollectionItems(NodeInterface $collection) {
+    $ids = \Drupal::entityTypeManager()
+      ->getStorage('os2loop_document_collection_item')
+      ->getQuery()
+      ->condition('collection_id', $collection->id())
+      ->sort('weight')
+      ->execute();
+
+    $items = array_map(DocumentCollectionItem::class . '::load', $ids ?: []);
+
+    return $this->buildTree($items);
+  }
+
+  /**
+   * Update collection in database.
+   */
+  public function updateCollection(NodeInterface $node, array $data) {
+    $ids = \Drupal::entityTypeManager()
+      ->getStorage('os2loop_document_collection_item')
+      ->getQuery()
+      ->condition('collection_id', $node->id())
+      ->execute();
+    $items = DocumentCollectionItem::loadMultiple($ids);
+    foreach ($items as $item) {
+      $item->delete();
+    }
+
+    foreach ($data as $row) {
+      $item = DocumentCollectionItem::create([
+        'collection_id' => $node->id(),
+        'document_id' => $row['id'],
+        'parent_id' => $row['pid'],
+        'weight' => $row['weight'],
+      ]);
+      $item->save();
+    }
+  }
+
+  /**
+   * Add document to collection.
+   *
+   * @param \Drupal\node\Entity\NodeInterface $collection
+   *   The collection.
+   * @param \Drupal\node\Entity\NodeInterface $document
+   *   The document.
+   * @param \Drupal\node\Entity\NodeInterface|null $parent
+   *   The optional document parent.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function addDocument(NodeInterface $collection, NodeInterface $document, NodeInterface $parent = NULL) {
+    $items = $this->loadCollectionItems($collection);
+    $weight = -1;
+    foreach ($items as $item) {
+      $weight = max($weight, $item->weight->value);
+    }
+    if (isset($items[$document->id()])) {
+      throw new \InvalidArgumentException(sprintf('Document %s is already in collection %s', $document->id(), $collection->id()));
+    }
+    if (NULL !== $parent) {
+      if (!isset($items[$parent->id()])) {
+        throw new \InvalidArgumentException(sprintf('Parent document %s is not in collection %s', $parent->id(),
+          $collection->id()));
+      }
+      if ($parent->id() === $document->id()) {
+        throw new \InvalidArgumentException(sprintf('Cannot add document %s as a child of itself', $document->id()));
+      }
+    }
+
+    $item = DocumentCollectionItem::create([
+      'collection_id' => $collection->id(),
+      'document_id' => $document->id(),
+      'parent_id' => $parent ? $parent->id() : 0,
+      'weight' => $weight + 1,
+    ])->save();
+  }
+
+  /**
+   * Remove document from collection.
+   *
+   * @param \Drupal\node\Entity\NodeInterface $collection
+   *   The collection.
+   * @param \Drupal\node\Entity\NodeInterface $document
+   *   The document.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function removeDocument(NodeInterface $collection, NodeInterface $document) {
+    $items = $this->loadCollectionItems($collection);
+    if (!isset($items[$document->id()])) {
+      throw new \InvalidArgumentException(sprintf('Document %s is not in collection %s', $document->id(), $collection->id()));
+    }
+    // Delete document and any children.
+    foreach ($items as $item) {
+      if ((int) $document->id() === (int) $item->document_id->value
+        || (int) $document->id() === (int) $item->parent_id->value) {
+        $item->delete();
+      }
+    }
+  }
+
+  /**
+   * Get collection items.
+   *
+   * @param array $data
+   *   The data.
+   *
+   * @return array
+   *   The collection items.
+   */
+  public function getCollectionItems(array $data) {
+    $this->addDepths($data);
+    $this->sortItems($data);
+    $nodes = Node::loadMultiple(array_keys($data));
+    foreach ($data as &$item) {
+      $node = $nodes[$item['id']] ?? NULL;
+      $item['node'] = $node;
+      $item['name'] = $node ? sprintf('%s (%s)', $node->getTitle(), $node->id()) : $item['id'];
+    }
+
+    return $data;
+  }
+
+  /**
+   * Get collection tree.
+   *
+   * @param array $data
+   *   The data.
+   *
+   * @return array
+   *   The collection tree.
+   */
+  public function getCollectionTree(array $data) {
+    $items = $this->getCollectionItems($data);
+    $this->buildTree($items);
+
+    return $items;
+  }
+
+  /**
+   * Sort items.
+   *
+   * @param array $items
+   *   The itens.
+   */
+  public function sortItems(array &$items) {
+  }
+
+  /**
+   * Add depth to items in a list of items with weight and parent id (pid).
+   */
+  public function addDepths(array &$items, int $parentId = 0, int $parentDepth = -1) {
+    foreach ($items as &$item) {
+      if ($parentId === (int) $item['pid']) {
+        $item['depth'] = $parentDepth + 1;
+        $this->addDepths($items, $item['id'], $item['depth']);
+      }
+    }
+  }
+
+  /**
+   * Build a tree from a list of items with weight and parent id (pid).
+   *
+   * @param array $items
+   *   The items.
+   * @param array $tree
+   *   The tree being built. Internal use only.
+   * @param int $depth
+   *   The depth. Internal use only.
+   * @param int $parent
+   *   The parent. Internal use only.
+   *
+   * @return array
+   *   The tree.
+   */
+  public function buildTree(array $items, array &$tree = [], $depth = 0, $parent = 0): array {
+    $roots = array_filter($items, static function (DocumentCollectionItem $item) use ($parent) {
+      return $item->parent_id->value == $parent;
+    });
+
+    foreach ($roots as $root) {
+      $id = $root->document_id->value;
+      $root->depth = $depth;
+      $tree[$id] = $root;
+      $this->buildTree($items, $tree, $depth + 1, $id);
+    }
+
+    return $tree;
+  }
+
+  /**
+   * Array of item parents keyed by collection ID and child item ID.
+   *
+   * @var array
+   */
+  protected $treeParents = [];
+
+  /**
+   * Array of item ancestors keyed by collection ID and parent item ID.
+   *
+   * @var array
+   */
+  protected $treeChildren = [];
+
+  /**
+   * Array of items in a tree keyed by collection ID and item ID.
+   *
+   * @var array
+   */
+  protected $treeItems = [];
+
+  /**
+   * Lifted from Drupal\taxonomy\TermStorage::loadTree().
+   *
+   * @return \Drupal\os2loop_documents\Entity\DocumentCollectionItem[]
+   *   The tree.
+   */
+  public function loadTree(int $collectionId, int $parent = 0, int $max_depth = NULL, bool $load_entities = FALSE) {
+    $cache_key = implode(':', func_get_args());
+    if (!isset($this->trees[$cache_key])) {
+      // We cache trees, so it's not CPU-intensive to call on an item and its
+      // children, too.
+      if (!isset($this->treeChildren[$collectionId])) {
+        $this->treeChildren[$collectionId] = [];
+        $this->treeParents[$collectionId] = [];
+        $this->treeItems[$collectionId] = [];
+        $result = $this->loadCollectionItems(Node::load($collectionId));
+        foreach ($result as $item) {
+          $this->treeChildren[$collectionId][$item->parent_id->value][] = $item->document_id->value;
+          $this->treeParents[$collectionId][$item->document_id->value][] = $item->parent_id->value;
+          $this->treeItems[$collectionId][$item->document_id->value] = $item;
+        }
+      }
+
+      // Load full entities, if necessary. The entity controller statically
+      // caches the results.
+      $item_entities = [];
+      if ($load_entities) {
+        $item_entities = $this->loadMultiple(array_keys($this->treeItems[$collectionId]));
+      }
+
+      if (NULL === $max_depth) {
+        $max_depth = count($this->treeChildren[$collectionId]);
+      }
+      $tree = [];
+
+      // Keeps track of the parents we have to process, the last entry is used
+      // for the next processing step.
+      $process_parents = [];
+      $process_parents[] = $parent;
+
+      // Loops over the parent items and adds its children to the tree array.
+      // Uses a loop instead of a recursion, because it's more efficient.
+      while (count($process_parents)) {
+        $parent = array_pop($process_parents);
+        // The number of parents determines the current depth.
+        $depth = count($process_parents);
+        if ($max_depth > $depth && !empty($this->treeChildren[$collectionId][$parent])) {
+          $has_children = FALSE;
+          $child = current($this->treeChildren[$collectionId][$parent]);
+          do {
+            if (empty($child)) {
+              break;
+            }
+            $item = $load_entities ? $item_entities[$child] : $this->treeItems[$collectionId][$child];
+            if (isset($this->treeParents[$collectionId][$load_entities ? $item->id() : $item->document_id->value])) {
+              // Clone the item so that the depth attribute remains correct
+              // in the event of multiple parents.
+              $item = clone $item;
+            }
+            $item->depth = $depth;
+            $tid = $load_entities ? $item->id() : $item->document_id->value;
+            $tree[] = $item;
+            if (!empty($this->treeChildren[$collectionId][$tid])) {
+              $has_children = TRUE;
+
+              // We have to continue with this parent later.
+              $process_parents[] = $parent;
+              // Use the current item as parent for the next iteration.
+              $process_parents[] = $tid;
+
+              // Reset pointers for child lists because we step in there more
+              // often with multi parents.
+              reset($this->treeChildren[$collectionId][$tid]);
+              // Move pointer so that we get the correct item the next time.
+              next($this->treeChildren[$collectionId][$parent]);
+              break;
+            }
+          } while ($child = next($this->treeChildren[$collectionId][$parent]));
+
+          if (!$has_children) {
+            // We processed all items in this hierarchy-level, reset pointer
+            // so that this function works the next time it gets called.
+            reset($this->treeChildren[$collectionId][$parent]);
+          }
+        }
+      }
+      $this->trees[$cache_key] = $tree;
+    }
+
+    return $this->trees[$cache_key];
+  }
+
+  /**
+   * Get descendants.
+   *
+   * @param int|array $root
+   *   The root.
+   * @param array $data
+   *   The descendants.
+   */
+  public function getDescendants($root, array $data): array {
+    return [];
+  }
+
+  /**
+   * Decide if an item has children.
+   */
+  public function hasChildren($item, array &$data) {
+    $itemId = $this->getItemId($item);
+
+    foreach ($data as $datum) {
+      if ($itemId === (int) $datum['pid']) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Remove item and descendants.
+   *
+   * @param int|array $item
+   *   The item.
+   * @param array $data
+   *   The descendants.
+   */
+  public function removeItem($item, array &$data) {
+    $itemId = $this->getItemId($item);
+    unset($data[$itemId]);
+    $descendants = $this->getDescendants($itemId, $data);
+    foreach ($descendants as $id) {
+      unset($data[$id]);
+    }
+  }
+
+  /**
+   * Get item id.
+   *
+   * @param int|array $item
+   *   The item.
+   *
+   * @return int|null
+   *   The item id.
+   */
+  private function getItemId($item) {
+    return is_scalar($item) ? $item : ($item['id'] ?? NULL);
+  }
+
+}

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/FormHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/FormHelper.php
@@ -4,11 +4,82 @@ namespace Drupal\os2loop_documents\Helper;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\NodeInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\MainContent\AjaxRenderer;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Form helper.
  */
 class FormHelper {
+  // @see https://www.drupal.org/project/media_library_form_element/issues/3155313#comment-13859469.
+  use DependencySerializationTrait;
+  use StringTranslationTrait;
+
+  private const DOCUMENTS = 'os2loop_documents_documents';
+  private const DOCUMENTS_TREE = 'os2loop_documents_tree';
+  private const DOCUMENTS_MESSAGE = 'documents_message';
+
+  /**
+   * The collection helper.
+   *
+   * @var CollectionHelper
+   */
+  private $collectionHelper;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  private $renderer;
+
+  /**
+   * The ajax renderer.
+   *
+   * @var \Drupal\Core\Render\MainContent\AjaxRenderer
+   */
+  private $ajaxRenderer;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  private $requestStack;
+
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  private $routeMatch;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  private $messenger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(CollectionHelper $collectionHelper, RendererInterface $renderer, AjaxRenderer $ajaxRenderer, RequestStack $requestStack, RouteMatchInterface $routeMatch, MessengerInterface $messenger) {
+    $this->collectionHelper = $collectionHelper;
+    $this->renderer = $renderer;
+    $this->ajaxRenderer = $ajaxRenderer;
+    $this->requestStack = $requestStack;
+    $this->routeMatch = $routeMatch;
+    $this->messenger = $messenger;
+  }
 
   /**
    * Implements hook_form_BASE_FORM_ID_alter().
@@ -22,6 +93,399 @@ class FormHelper {
           unset($form['os2loop_documents_document_body']);
         }
     }
+
+    if ('node_os2loop_documents_collection_edit_form' === $formId) {
+      $node = $formState->getformObject()->getEntity();
+      if (NULL !== $node && $node->getType() === NodeHelper::CONTENT_TYPE_COLLECTION) {
+        if (!$formState->isSubmitted()) {
+          $collection = $this->collectionHelper->loadCollectionItems($node);
+          $data = array_map(static function ($item) {
+            return [
+              'id' => $item->document_id->value,
+              'pid' => $item->parent_id->value,
+              'weight' => $item->weight->value,
+            ];
+          }, $collection);
+          $this->setDocumentsData($formState, $data);
+          $formState->setRebuild(TRUE);
+        }
+
+        $this->buildDocumentTree($form, $formState, $node);
+      }
+    }
+  }
+
+  /**
+   * Build document tree.
+   */
+  private function buildDocumentTree(array &$form, FormStateInterface $formState, NodeInterface $node) {
+    $form['documents_label'] = [
+      '#type' => 'label',
+      '#title' => $this->t('Documents'),
+    ];
+
+    $form[self::DOCUMENTS] = [
+      '#type' => 'container',
+      '#title' => $this->t('Documents'),
+      '#prefix' => '<div id="collection-documents-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    $form[self::DOCUMENTS][self::DOCUMENTS_TREE] = [
+      '#type' => 'table',
+      '#empty' => $this->t('No documents added yet.'),
+      // TableDrag: Each array value is a list of callback arguments for
+      // drupal_add_tabledrag(). The #id of the table is automatically
+      // prepended; if there is none, an HTML ID is auto-generated.
+      '#tabledrag' => [
+        [
+          'action' => 'match',
+          'relationship' => 'parent',
+          'group' => 'row-pid',
+          'source' => 'row-id',
+          'hidden' => TRUE, /* hides the WEIGHT & PARENT tree columns below */
+          'limit' => FALSE,
+        ],
+        [
+          'action' => 'order',
+          'relationship' => 'sibling',
+          'group' => 'row-weight',
+        ],
+      ],
+    ];
+
+    // Build the table rows and columns.
+    //
+    // The first nested level in the render array forms the table row, on which
+    // you likely want to set #attributes and #weight.
+    // Each child element on the second level represents a table column cell in
+    // the respective table row, which are render elements on their own. For
+    // single output elements, use the table cell itself for the render element.
+    // If a cell should contain multiple elements, simply use nested sub-keys to
+    // build the render element structure for the renderer service as you would
+    // everywhere else.
+    // $results = self::getData();
+    $results = $this->getCollectionDocuments($formState, $node);
+
+    $treeForm = &$form[self::DOCUMENTS][self::DOCUMENTS_TREE];
+    foreach ($results as $row) {
+      // TableDrag: Mark the table row as draggable.
+      $treeForm[$row['id']]['#attributes']['class'][] = 'draggable';
+
+      // Indent item on load.
+      $indentation = [];
+      if (isset($row['depth']) && $row['depth'] > 0) {
+        $indentation = [
+          '#theme' => 'indentation',
+          '#size' => $row['depth'],
+        ];
+      }
+
+      // Some table columns containing raw markup.
+      $treeForm[$row['id']]['name'] = [
+        '#markup' => $row['name'],
+        '#prefix' => !empty($indentation) ? $this->renderer->render($indentation) : '',
+      ];
+
+      $treeForm[$row['id']]['actions'] = [
+        'remove' => [
+          '#type' => 'submit',
+          '#submit' => [[$this, 'removeDocumentSubmit']],
+          '#ajax' => [
+            'callback' => [$this, 'removeDocumentResult'],
+            'wrapper' => 'collection-documents-wrapper',
+            'progress' => [
+              'type' => 'throbber',
+              'message' => NULL,
+            ],
+          ],
+          // We must have unique values to make FormState::getTriggeringElement
+          // work as expected.
+          '#value' => $this->t('Remove %document from collection', ['%document' => $row['name']]),
+          '#attributes' => [
+            'data-document-id' => $row['id'],
+            // @todo Show only on leaf nodes.
+            // 'class' => ['visually-hidden'],
+          ],
+        ],
+      ];
+
+      // This is hidden from #tabledrag array (above).
+      // TableDrag: Weight column element.
+      $treeForm[$row['id']]['weight'] = [
+        '#type' => 'weight',
+        '#title' => $this->t('Weight for ID @id', ['@id' => $row['id']]),
+        '#title_display' => 'invisible',
+        '#default_value' => $row['weight'],
+        // Classify the weight element for #tabledrag.
+        '#attributes' => [
+          'class' => ['row-weight'],
+        ],
+      ];
+      $treeForm[$row['id']]['parent']['id'] = [
+        '#parents' => [self::DOCUMENTS_TREE, $row['id'], 'id'],
+        '#type' => 'hidden',
+        '#value' => $row['id'],
+        '#attributes' => [
+          'class' => ['row-id'],
+        ],
+      ];
+      $treeForm[$row['id']]['parent']['pid'] = [
+        '#parents' => [self::DOCUMENTS_TREE, $row['id'], 'pid'],
+        '#type' => 'number',
+        '#size' => 3,
+        '#min' => 0,
+        '#title' => $this->t('Parent ID'),
+        '#default_value' => $row['pid'],
+        '#attributes' => [
+          'class' => ['row-pid'],
+        ],
+      ];
+    }
+
+    $form[self::DOCUMENTS]['add_document'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['container-inline']],
+      // '#weight' => 100,
+      '#prefix' => '<div id="loop-documents-add-document">',
+      '#suffix' => '</div>',
+    ];
+
+    $form[self::DOCUMENTS]['add_document']['document'] = [
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'node',
+      '#element_validate' => [[$this, 'validateDocument']],
+      '#selection_settings' => [
+        'target_bundles' => ['os2loop_documents_document'],
+      ],
+      '#prefix' => '<div id="loop-documents-menu-document-options">',
+      '#suffix' => '</div>',
+    ];
+
+    $form[self::DOCUMENTS]['add_document']['message'] = [
+      '#markup' => $formState->get(self::DOCUMENTS_MESSAGE) ?? '',
+    ];
+
+    $form[self::DOCUMENTS]['add_document']['actions']['submit'] = [
+      '#type' => 'submit',
+      '#submit' => [[$this, 'addDocumentSubmit']],
+      // @see https://www.drupal.org/docs/drupal-apis/ajax-api/basic-concepts#sub_form
+      '#ajax' => [
+        'callback' => [$this, 'addDocumentResult'],
+        'wrapper' => 'collection-documents-wrapper',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => NULL,
+        ],
+      ],
+      '#value' => $this->t('Add document'),
+    ];
+
+    $form['actions']['submit']['#submit'][] = [$this, 'documentsSubmit'];
+  }
+
+  /**
+   * Add document submit handler.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   */
+  public function addDocumentSubmit(array &$form, FormStateInterface $formState) {
+    $data = $formState->getValue(self::DOCUMENTS_TREE) ?: [];
+    $documentId = $this->getDocumentId($formState);
+    if (NULL !== $documentId) {
+      $document = Node::load($documentId);
+      if ($document && !isset($data[$document - > id()])) {
+        $weight = (int) max(array_column($data, 'weight'));
+        $data[$document - > id()] = [
+          'weight' => $weight + 1,
+          'id' => $document->id(),
+          'pid' => 0,
+        ];
+        $this->messenger->addStatus($this->t('Document added to collection.'));
+      }
+      else {
+        $this->messenger->addWarning($this->t('Document already in collection.'));
+      }
+    }
+    $this->setDocumentsData($formState, $data);
+    $formState->setRebuild(TRUE);
+  }
+
+  /**
+   * Add document ajax callback.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   *
+   * @return array
+   *   The form element.
+   */
+  public function addDocumentResult(array &$form, FormStateInterface $formState) {
+    return $form[self::DOCUMENTS];
+  }
+
+  /**
+   * Remove document submit handler.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   */
+  public function removeDocumentSubmit(array &$form, FormStateInterface $formState) {
+    // $this->getDocumentsData($formState);
+    $data = $formState->getValue(self::DOCUMENTS_TREE) ?: [];
+    $trigger = $formState->getTriggeringElement();
+    if (isset($trigger['#attributes']['data-document-id'])) {
+      $documentId = (int) $trigger['#attributes']['data-document-id'];
+      // Only leaf documents can be removed.
+      if (!$this->collectionHelper->hasChildren($documentId, $data)) {
+        unset($data[$documentId]);
+        $this->messenger->addStatus($this->t('Document removed from collection.'));
+      }
+      else {
+        $this->messenger->addError($this->t('Only leaf documents can be removed.'));
+      }
+    }
+    $this->setDocumentsData($formState, $data);
+    $formState->setRebuild(TRUE);
+  }
+
+  /**
+   * Remove document ajax callback.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   *
+   * @return array
+   *   The form element.
+   */
+  public function removeDocumentResult(array &$form, FormStateInterface $formState) {
+    $element = $this->addDocumentResult($form, $formState);
+    $response = $this->ajaxRenderer->renderResponse($element, $this->requestStack->getCurrentRequest(), $this->routeMatch);
+    // @todo Trigger "You have unsaved changes" warning.
+    // $response->addCommand(…);
+    return $response;
+  }
+
+  /**
+   * Submit handler.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   */
+  public function documentsSubmit(array &$form, FormStateInterface $formState) {
+    $data = $formState->getValue(self::DOCUMENTS_TREE);
+    if (!is_array($data)) {
+      $data = [];
+    }
+    $node = $formState->getformObject()->getEntity();
+    $this->collectionHelper->updateCollection($node, $data);
+  }
+
+  /**
+   * Set documents data.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   * @param array $data
+   *   The data.
+   *
+   * @return \Drupal\Core\Form\FormStateInterface
+   *   The form state.
+   */
+  private function setDocumentsData(FormStateInterface $formState, array $data) {
+    return $formState->setValue(self::DOCUMENTS_TREE, $data);
+  }
+
+  /**
+   * Get documents data.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   *
+   * @return array
+   *   The data.
+   */
+  private function getDocumentsData(FormStateInterface $formState) {
+    return $formState->getValue(self::DOCUMENTS_TREE) ?? [];
+  }
+
+  /**
+   * Get document id from form state.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   *
+   * @return int|null
+   *   The document id if any.
+   */
+  private function getDocumentId(FormStateInterface $formState) {
+    $spec = $formState->getValue('document');
+    if (preg_match('/^\d+$/', $spec)) {
+      return (int) $spec;
+    }
+    if (preg_match('/\((?<id>\d+)\)$/', $spec, $matches)) {
+      return (int) $matches['id'];
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Validate document.
+   */
+  public function validateDocument(array &$element, FormStateInterface $formState) {
+    // @todo This should only run on document add.
+    if (1 === 1) {
+      return;
+    }
+    $trigger = $formState->getTriggeringElement();
+    $documentId = $this->getDocumentId($formState);
+    if (NULL !== $documentId) {
+      $data = $this->getDocumentsData($formState);
+      $document = Node::load($documentId);
+      $errorMessage = NULL;
+      if (NULL === $document) {
+        $errorMessage = $this->t('Missing document');
+      }
+      elseif (NodeHelper::CONTENT_TYPE_DOCUMENT !== $document->getType()) {
+        $errorMessage = $this->t('Invalid document type (@type)', [
+          '@type' => $document->getType(),
+        ]);
+      }
+      elseif (isset($data[$document - > id()])) {
+        $errorMessage = $this->t('Document @title (@id) already in collection', [
+          '@title' => $document->getTitle(),
+          '@id' => $document->id(),
+        ]);
+      }
+    }
+    else {
+      $errorMessage = $this->t('No document specified');
+    }
+
+    if (NULL !== $errorMessage) {
+      $formState->setErrorByName('document', $errorMessage);
+    }
+  }
+
+  /**
+   * Get collection documents.
+   */
+  private function getCollectionDocuments(FormStateInterface $formState, NodeInterface $node) {
+    $data = $this->getDocumentsData($formState);
+
+    return $this->collectionHelper->getCollectionItems($data);
   }
 
   /**

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/FormHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/FormHelper.php
@@ -102,7 +102,7 @@ class FormHelper {
           $data = array_map(static function ($item) {
             return [
               'id' => $item->document_id->value,
-              'pid' => $item->parent_id->value,
+              'pid' => $item->parent_document_id->value,
               'weight' => $item->weight->value,
             ];
           }, $collection);

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/FormHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/FormHelper.php
@@ -509,7 +509,7 @@ class FormHelper {
 
     $body = $node->get('os2loop_documents_document_body')->value;
     return !empty(strip_tags($body ?? ''));
-    }
+  }
 
   /**
    * Build unique document title.

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/NodeHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/NodeHelper.php
@@ -3,6 +3,7 @@
 namespace Drupal\os2loop_documents\Helper;
 
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Node helper.
@@ -19,10 +20,18 @@ class NodeHelper {
   private $collectionHelper;
 
   /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  private $requestStack;
+
+  /**
    * Constructor.
    */
-  public function __construct(CollectionHelper $collectionHelper) {
+  public function __construct(CollectionHelper $collectionHelper, RequestStack $requestStack) {
     $this->collectionHelper = $collectionHelper;
+    $this->requestStack = $requestStack;
   }
 
   /**
@@ -40,22 +49,32 @@ class NodeHelper {
     $node = $variables['node'];
     if (self::CONTENT_TYPE_COLLECTION === $node->getType()) {
       $items = $this->collectionHelper->loadTree($node->id());
-      $variables['content']['os2loop_documents_collection_tree'] = [
-        '#type' => 'fieldset',
-        '#title' => __METHOD__,
-      ];
-
-      foreach ($items as $id => $item) {
-        $variables['content']['os2loop_documents_collection_tree'][$id] = [
-          '#markup' => implode('; ', [
-            $item->parent_id->value,
-            $item->depth,
-            $item->document_id->value,
-          ]),
-          '#prefix' => '<pre>',
-          '#suffix' => '</pre>',
-        ];
+      $items = $this->collectionHelper->buildDocumentTree($items);
+      $variables['os2loop_documents_collection_tree'] = $items;
+    }
+    elseif (self::CONTENT_TYPE_DOCUMENT === $node->getType()) {
+      $collections = $this->collectionHelper->loadCollections($node);
+      // Check if we have a request for a specific collection.
+      $request = $this->requestStack->getCurrentRequest();
+      $collectionId = NULL !== $request ? $request->query->get('collection') : NULL;
+      if (isset($collections[$collectionId])) {
+        $collections = [$collections[$collectionId]];
       }
+      if (1 === count($collections)) {
+        $collection = reset($collections);
+        $items = $this->collectionHelper->loadTree($collection->id());
+        $items = $this->collectionHelper->buildDocumentTree($items);
+        $variables['os2loop_documents_collection'] = $collection;
+        $variables['os2loop_documents_collection_tree'] = $items;
+      }
+      elseif (count($collections) > 1) {
+        $variables['os2loop_documents_collections'] = $collections;
+      }
+
+      // Make sure that the "collection" query parameter is considered when
+      // caching (cf.
+      // https://www.drupal.org/docs/drupal-apis/cache-api/cache-contexts).
+      $variables['#cache']['contexts'][] = 'url.query_args:collection';
     }
   }
 

--- a/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/NodeHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_documents/src/Helper/NodeHelper.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Drupal\os2loop_documents\Helper;
+
+use Drupal\node\NodeInterface;
+
+/**
+ * Node helper.
+ */
+class NodeHelper {
+  public const CONTENT_TYPE_DOCUMENT = 'os2loop_documents_document';
+  public const CONTENT_TYPE_COLLECTION = 'os2loop_documents_collection';
+
+  /**
+   * The collection helper.
+   *
+   * @var CollectionHelper
+   */
+  private $collectionHelper;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(CollectionHelper $collectionHelper) {
+    $this->collectionHelper = $collectionHelper;
+  }
+
+  /**
+   * Implements hook_ENTITY_TYPE_update().
+   */
+  public function updateNode(NodeInterface $node) {
+    // @todo Clear collection cache when document is updated.
+  }
+
+  /**
+   * Implements hook_preprocess_HOOK().
+   */
+  public function preprocessNode(array &$variables) {
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $variables['node'];
+    if (self::CONTENT_TYPE_COLLECTION === $node->getType()) {
+      $items = $this->collectionHelper->loadTree($node->id());
+      $variables['content']['os2loop_documents_collection_tree'] = [
+        '#type' => 'fieldset',
+        '#title' => __METHOD__,
+      ];
+
+      foreach ($items as $id => $item) {
+        $variables['content']['os2loop_documents_collection_tree'][$id] = [
+          '#markup' => implode('; ', [
+            $item->parent_id->value,
+            $item->depth,
+            $item->document_id->value,
+          ]),
+          '#prefix' => '<pre>',
+          '#suffix' => '</pre>',
+        ];
+      }
+    }
+  }
+
+}

--- a/web/profiles/custom/os2loop/os2loop.info.yml
+++ b/web/profiles/custom/os2loop/os2loop.info.yml
@@ -27,6 +27,7 @@ distribution:
 
 # # Modules to install to support the profile.
 install:
+  # @todo Complete this list of dependencies
   - history
   - block_content
   - breakpoint
@@ -52,8 +53,10 @@ install:
 # # Required modules
 # # Note that any dependencies of the modules listed here will be installed automatically.
 dependencies:
-  - node
+  # @todo Complete this list of dependencies
   - block
+  - node
+  - twig_tweak
   - views
 
 # # List any themes that should be installed as part of the profile installation.

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/README.md
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/README.md
@@ -1,0 +1,29 @@
+# OS2Loop theme
+
+This is the default theme for OS2Loop.
+
+## Building assets
+
+Assets are built using [Symfony
+Encore](https://symfony.com/doc/current/frontend/encore/installation.html#installing-encore-in-non-symfony-applications).
+
+Build assets (JavaScript and CSS) by running
+
+```sh
+docker run --volume ${PWD}:/app --workdir /app node:latest yarn install
+docker run --volume ${PWD}:/app --workdir /app node:latest yarn build
+```
+
+During development you may want to run it with your locally installed
+[`yarn`](https://classic.yarnpkg.com/en/docs/install/) binary:
+
+```sh
+yarn install
+yarn build
+```
+
+and maybe even watch for changes:
+
+```sh
+yarn watch
+```

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/pdf/pdf.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/pdf/pdf.scss
@@ -1,0 +1,5 @@
+.os2loop-documents--collection-documents {
+  .os2loop-documents--document-content {
+    // Document rendered as part of collection.
+  }
+}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/os2loop_theme.info.yml
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/os2loop_theme.info.yml
@@ -26,3 +26,8 @@ regions:
   content: Content
   sidebar_first: 'Sidebar first'
   footer: Footer
+
+# Styling for entity_print (cf. https://www.drupal.org/node/2706755#from-your-theme)
+entity_print:
+  node:
+    all: 'os2loop_theme/pdf-styling'

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/os2loop_theme.info.yml
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/os2loop_theme.info.yml
@@ -5,6 +5,11 @@ description: 'A theme for os2loop.'
 core_version_requirement: ^8 || ^9
 screenshot: loop.png
 
+# This breaks `drush site:install` (maybe related to
+# https://www.drupal.org/project/drupal/issues/3100374).
+# dependencies:
+#   - drupal:twig_tweak
+
 libraries:
   - os2loop_theme/global-styling
   - os2loop_theme/global-scripts

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/os2loop_theme.libraries.yml
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/os2loop_theme.libraries.yml
@@ -7,3 +7,9 @@ global-scripts:
   version: 1.x
   js:
     build/app.js: {  }
+
+pdf-styling:
+  version: 1.x
+  css:
+    theme:
+      build/pdf.css: {}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection--pdf.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection--pdf.html.twig
@@ -1,0 +1,142 @@
+{#
+  /**
+  * @file
+  * Default theme implementation to display a node.
+  *
+  * Available variables:
+  * - node: The node entity with limited access to object properties and methods.
+  *   Only method names starting with "get", "has", or "is" and a few common
+  *   methods such as "id", "label", and "bundle" are available. For example:
+  *   - node.getCreatedTime() will return the node creation timestamp.
+  *   - node.hasField('field_example') returns TRUE if the node bundle includes
+  *     field_example. (This does not indicate the presence of a value in this
+  *     field.)
+  *   - node.isPublished() will return whether the node is published or not.
+  *   Calling other methods, such as node.delete(), will result in an exception.
+  *   See \Drupal\node\Entity\Node for a full list of public properties and
+  *   methods for the node object.
+  * - label: (optional) The title of the node.
+  * - content: All node items. Use {{ content }} to print them all,
+  *   or print a subset such as {{ content.field_example }}. Use
+  *   {{ content|without('field_example') }} to temporarily suppress the printing
+  *   of a given child element.
+  * - author_picture: The node author user entity, rendered using the "compact"
+  *   view mode.
+  * - metadata: Metadata for this node.
+  * - date: (optional) Themed creation date field.
+  * - author_name: (optional) Themed author name field.
+  * - url: Direct URL of the current node.
+  * - display_submitted: Whether submission information should be displayed.
+  * - attributes: HTML attributes for the containing element.
+  *   The attributes.class element may contain one or more of the following
+  *   classes:
+  *   - node: The current template type (also known as a "theming hook").
+  *   - node--type-[type]: The current node type. For example, if the node is an
+  *     "Article" it would result in "node--type-article". Note that the machine
+  *     name will often be in a short form of the human readable label.
+  *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+  *     teaser would result in: "node--view-mode-teaser", and
+  *     full: "node--view-mode-full".
+  *   The following are controlled through the node publishing options.
+  *   - node--promoted: Appears on nodes promoted to the front page.
+  *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+  *     teaser listings.
+  *   - node--unpublished: Appears on unpublished nodes visible only to site
+  *     admins.
+  * - title_attributes: Same as attributes, except applied to the main title
+  *   tag that appears in the template.
+  * - content_attributes: Same as attributes, except applied to the main
+  *   content tag that appears in the template.
+  * - author_attributes: Same as attributes, except applied to the author of
+  *   the node tag that appears in the template.
+  * - title_prefix: Additional output populated by modules, intended to be
+  *   displayed in front of the main title tag that appears in the template.
+  * - title_suffix: Additional output populated by modules, intended to be
+  *   displayed after the main title tag that appears in the template.
+  * - view_mode: View mode; for example, "teaser" or "full".
+  * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+  * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+  * - readmore: Flag for more state. Will be true if the teaser content of the
+  *   node cannot hold the main body content.
+  * - logged_in: Flag for authenticated user status. Will be true when the
+  *   current user is a logged-in member.
+  * - is_admin: Flag for admin user status. Will be true when the current user
+  *   is an administrator.
+  *
+  * @see template_preprocess_node()
+  *
+  * @todo Remove the id attribute (or make it a class), because if that gets
+  *   rendered twice on a page this is invalid CSS for example: two lists
+  *   in different view modes.
+  *
+  * @ingroup themeable
+  */
+  #}
+{% macro table_of_contents(items, collection) %}
+  {% if items %}
+    <ol>
+      {% for item in items %}
+        {% set document = item.document %}
+        <li>
+          <a href="{{ path('entity.node.canonical', {node: document.id, collection: collection.id}) }}" class="document-title">{{ document.title.value }}</a>
+          {{ item.children ? _self.table_of_contents(item.children, collection) }}
+        </li>
+      {% endfor %}
+    </ol>
+  {% endif %}
+{% endmacro %}
+
+{% macro document_content(items, level=1) %}
+  {% if items %}
+    {% for item in items %}
+      {% set document = item.document %}
+      {% set tag_name = 'h' ~ level %}
+      <article class="os2loop-documents--collection-documents--document">
+        <{{ tag_name }}>{{ document.title.value }}</{{ tag_name }}>
+
+        {# Render document content (cf. https://www.drupal.org/docs/contributed-modules/twig-tweak-2x/cheat-sheet#s-drupal-entity). #}
+        {# Note that we must use `pdf_content` to make the template renderer pick up the `…-pdf-content` template (!) #}
+        {{ drupal_entity('node', document.id, 'pdf_content') }}
+
+        {{ item.children ? _self.document_content(item.children, level + 1) }}
+      </article>
+    {% endfor %}
+  {% endif %}
+{% endmacro %}
+
+<article{{ attributes.addClass("container") }}>
+  {{ title_prefix }}
+  {% if label  %}
+    <h1{{ title_attributes }}>
+      {{ label }}
+    </h1>
+  {% endif %}
+  {{ title_suffix }}
+
+  <div{{ content_attributes }}>
+    <div class="row">
+      <div class="col-md-9">
+        {{ content.os2loop_documents_dc_content }}
+
+        {% if os2loop_documents_collection_tree|default(false) %}
+          <fieldset>
+            <legend>{{ 'Documents in collection'|trans }}</legend>
+            {{ _self.table_of_contents(os2loop_documents_collection_tree, node) }}
+          </fieldset>
+          <div class="os2loop-documents--collection-documents">
+            {{ _self.document_content(os2loop_documents_collection_tree) }}
+          </div>
+        {% endif %}
+      </div>
+      <div class="col-md-3">
+        <div class="bg-secondary-loop">
+          <div> {{ content.os2loop_shared_profession }}</div>
+          <div> {{ content.os2loop_shared_tags }}</div>
+          <div> {{ content.os2loop_shared_subject }}</div>
+          <div> {{ content.os2loop_documents_document_autho }}</div>
+          <div> {{ content.flag_os2loop_favourite }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
@@ -120,4 +120,6 @@
         </div>
   </div>
 
+  {# @todo design #}
+  <a class="btn btn-secondary btn-print" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print collection (PDF)'|t }}</a>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
@@ -83,8 +83,9 @@
 
   <div{{ content_attributes }}>
   <div class="row">
-  <div class="col-md-9">
-    {{ content.os2loop_documents_dc_content }}
+    <div class="col-md-9">
+      {{ content.os2loop_documents_dc_content }}
+      {{ content.os2loop_documents_collection_tree }}
     </div>
     <div class="col-md-3">
         <div class="bg-secondary-loop">

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
@@ -79,9 +79,7 @@
         {% set document = item.document %}
         <li>
           <a href="{{ path('entity.node.canonical', {node: document.id, collection: collection.id}) }}" class="document-title">{{ document.title.value }}</a>
-          {% if item.children %}
-            {{ _self.table_of_contents(item.children) }}
-          {% endif %}
+          {{ item.children ? _self.table_of_contents(item.children, collection) }}
         </li>
       {% endfor %}
     </ol>
@@ -99,14 +97,16 @@
 
   <div{{ content_attributes }}>
   <div class="row">
-  <div class="col-md-9">
-    {% if os2loop_documents_collection_tree|default(false) %}
-      <fieldset>
-        <legend>{{ 'Documents in collection'|trans }}</legend>
-        {{ _self.table_of_contents(os2loop_documents_collection_tree, node) }}
-      </fieldset>
-    {% endif %}
-    {{ content.os2loop_documents_dc_content }}
+    <div class="col-md-9">
+      {{ content.os2loop_documents_dc_content }}
+
+      {% if os2loop_documents_collection_tree|default(false) %}
+        <fieldset>
+          <legend>{{ 'Documents in collection'|trans }}</legend>
+          {{ _self.table_of_contents(os2loop_documents_collection_tree, node) }}
+        </fieldset>
+      {% endif %}
+
     </div>
     <div class="col-md-3">
         <div class="bg-secondary-loop">
@@ -121,5 +121,5 @@
   </div>
 
   {# @todo design #}
-  <a class="btn btn-secondary btn-print" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print collection (PDF)'|t }}</a>
+  <a class="btn btn-secondary btn-print d-print-none" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print collection (PDF)'|t }}</a>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
@@ -72,6 +72,22 @@
  * @ingroup themeable
  */
 #}
+{% macro table_of_contents(items, collection) %}
+  {% if items %}
+    <ol>
+      {% for item in items %}
+        {% set document = item.document %}
+        <li>
+          <a href="{{ path('entity.node.canonical', {node: document.id, collection: collection.id}) }}" class="document-title">{{ document.title.value }}</a>
+          {% if item.children %}
+            {{ _self.table_of_contents(item.children) }}
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ol>
+  {% endif %}
+{% endmacro %}
+
 <article{{ attributes.addClass("container") }}>
   {{ title_prefix }}
   {% if label  %}
@@ -84,6 +100,12 @@
   <div{{ content_attributes }}>
   <div class="row">
     <div class="col-md-9">
+      {% if os2loop_documents_collection_tree|default(false) %}
+        <fieldset>
+          <legend>{{ 'Documents in collection'|trans }}</legend>
+          {{ _self.table_of_contents(os2loop_documents_collection_tree, node) }}
+        </fieldset>
+      {% endif %}
       {{ content.os2loop_documents_dc_content }}
       {{ content.os2loop_documents_collection_tree }}
     </div>
@@ -95,8 +117,8 @@
           <div> {{ content.os2loop_documents_document_autho }}</div>
           <div> {{ content.flag_os2loop_favourite }}</div>
         </div>
-        </div>
-        </div>
+      </div>
+    </div>
   </div>
 
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
@@ -99,15 +99,14 @@
 
   <div{{ content_attributes }}>
   <div class="row">
-    <div class="col-md-9">
-      {% if os2loop_documents_collection_tree|default(false) %}
-        <fieldset>
-          <legend>{{ 'Documents in collection'|trans }}</legend>
-          {{ _self.table_of_contents(os2loop_documents_collection_tree, node) }}
-        </fieldset>
-      {% endif %}
-      {{ content.os2loop_documents_dc_content }}
-      {{ content.os2loop_documents_collection_tree }}
+  <div class="col-md-9">
+    {% if os2loop_documents_collection_tree|default(false) %}
+      <fieldset>
+        <legend>{{ 'Documents in collection'|trans }}</legend>
+        {{ _self.table_of_contents(os2loop_documents_collection_tree, node) }}
+      </fieldset>
+    {% endif %}
+    {{ content.os2loop_documents_dc_content }}
     </div>
     <div class="col-md-3">
         <div class="bg-secondary-loop">
@@ -117,8 +116,8 @@
           <div> {{ content.os2loop_documents_document_autho }}</div>
           <div> {{ content.flag_os2loop_favourite }}</div>
         </div>
-      </div>
-    </div>
+        </div>
+        </div>
   </div>
 
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document--pdf-content.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document--pdf-content.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Display of document content when rendering collection including document content.
+#}
+
+<div class="os2loop-documents--document-content">
+  {% if content.os2loop_shared_subject %}
+    <div class="os2loop-shared-subject">{{ content.os2loop_shared_subject }}</div>
+  {% endif %}
+
+  {% if content.os2loop_shared_tags %}
+    <div class="os2loop-shared-tags">{{ content.os2loop_shared_tags }}</div>
+  {% endif %}
+
+  {% if content.os2loop_shared_profession %}
+    <div class="os2loop-shared-profession">{{ content.os2loop_shared_profession }}</div>
+  {% endif %}
+
+  <div class="os2loop-document-content">{{ content.os2loop_documents_document_conte }}</div>
+</div>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -81,9 +81,7 @@
           <a href="{{ path('entity.node.canonical', {node: document.id, collection: collection.id}) }}"
             {{ node.id == document.id ? 'class="active" aria-current="true"' }}
           ><span class="document-title">{{ document.title.value }}</span></a>
-          {% if item.children %}
-            {{ _self.table_of_contents(item.children, collection, node) }}
-          {% endif %}
+          {{ item.children ? _self.table_of_contents(item.children, collection, node) }}
         </li>
       {% endfor %}
     </ol>
@@ -91,63 +89,63 @@
 {% endmacro %}
 
 <article{{ attributes }}>
-	<ul class="tabs nav" id="document-tabs" role="tablist">
-		<li>
-			<a class="tab active" id="document-tab" data-toggle="tab" href="#document" role="tab" aria-controls="document" aria-selected="true">Document</a>
-		</li>
-		<li>
-			<a class="tab" id="about-document-tab" data-toggle="tab" href="#about-document" role="tab" aria-controls="about-document" aria-selected="false">About document</a>
-		</li>
-	</ul>
-	<div class="tab-content" id="document-tabs-content">
-		<div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
-			{{ title_prefix }}
-			{% if label  %}
-				<h1{{ title_attributes }}>
-					{{ label }}
-				</h1>
-			{% endif %}
-			{{ title_suffix }}
-			{% if os2loop_documents_collection_tree|default(false) %}
-				<fieldset>
-					<legend>{{ 'Documents in collection'|trans }}
-						<a href="{{ path('entity.node.canonical', {node: os2loop_documents_collection.id}) }}">{{ os2loop_documents_collection.title.value }}</a>
-					</legend>
-					{{ _self.table_of_contents(os2loop_documents_collection_tree, os2loop_documents_collection, node) }}
-				</fieldset>
-			{% elseif os2loop_documents_collections|default(false) %}
-				<fieldset>
-					<legend>{{ 'Document is part of these collections'|trans }}</legend>
-					<ol>
-						{% for collection in os2loop_documents_collections %}
-							<li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
-						{% endfor %}
-					</ol>
-				</fieldset>
-			{% endif %}
-			<div{{ content_attributes }}>
-				{{ content.os2loop_shared_subject }}
-				{{ content.os2loop_documents_document_conte }}
-			</div>
-		</div>
-		<div class="tab-pane" id="about-document" role="tabpanel" aria-labelledby="about-document-tab">
-			{{ title_prefix }}
-			{% if label  %}
-				<h1{{ title_attributes }}>
-					Om dokumentet
-				</h1>
-			{% endif %}
-			{{ title_suffix }}
-			{{ content.os2loop_documents_document_autho }}
-			<div{{ content_attributes.addClass("bg-secondary-loop") }}>
-				{{ content.os2loop_shared_tags }}
-				{{ content.os2loop_shared_subject }}
-				{{ content.os2loop_shared_profession }}
+  <ul class="tabs nav" id="document-tabs" role="tablist">
+    <li>
+      <a class="tab active" id="document-tab" data-toggle="tab" href="#document" role="tab" aria-controls="document" aria-selected="true">Document</a>
+    </li>
+    <li>
+      <a class="tab" id="about-document-tab" data-toggle="tab" href="#about-document" role="tab" aria-controls="about-document" aria-selected="false">About document</a>
+    </li>
+  </ul>
+  <div class="tab-content" id="document-tabs-content">
+    <div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
+      {{ title_prefix }}
+      {% if label  %}
+        <h1{{ title_attributes }}>
+          {{ label }}
+        </h1>
+      {% endif %}
+      {{ title_suffix }}
+      {% if os2loop_documents_collection_tree|default(false) %}
+        <fieldset>
+          <legend>{{ 'Documents in collection'|trans }}
+            <a href="{{ path('entity.node.canonical', {node: os2loop_documents_collection.id}) }}">{{ os2loop_documents_collection.title.value }}</a>
+          </legend>
+          {{ _self.table_of_contents(os2loop_documents_collection_tree, os2loop_documents_collection, node) }}
+        </fieldset>
+      {% elseif os2loop_documents_collections|default(false) %}
+        <fieldset>
+          <legend>{{ 'Document is part of these collections'|trans }}</legend>
+          <ol>
+            {% for collection in os2loop_documents_collections %}
+              <li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
+            {% endfor %}
+          </ol>
+        </fieldset>
+      {% endif %}
+      <div{{ content_attributes }}>
+        {{ content.os2loop_shared_subject }}
+        {{ content.os2loop_documents_document_conte }}
+      </div>
+    </div>
+    <div class="tab-pane" id="about-document" role="tabpanel" aria-labelledby="about-document-tab">
+      {{ title_prefix }}
+      {% if label  %}
+        <h1{{ title_attributes }}>
+          Om dokumentet
+        </h1>
+      {% endif %}
+      {{ title_suffix }}
+      {{ content.os2loop_documents_document_autho }}
+      <div{{ content_attributes.addClass("bg-secondary-loop") }}>
+        {{ content.os2loop_shared_tags }}
+        {{ content.os2loop_shared_subject }}
+        {{ content.os2loop_shared_profession }}
         {{ content.flag_os2loop_favourite }}
-			</div>
-		</div>
-	</div>
+      </div>
+    </div>
+  </div>
 
-	{# @todo design #}
-	<a class="btn btn-secondary btn-print" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print document (PDF)'|t }}</a>
+  {# @todo design #}
+  <a class="btn btn-secondary btn-print d-print-none" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print document (PDF)'|t }}</a>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -72,6 +72,24 @@
  * @ingroup themeable
  */
 #}
+{% macro table_of_contents(items, collection, node) %}
+  {% if items %}
+    <ol>
+      {% for item in items %}
+        {% set document = item.document %}
+        <li>
+          <a href="{{ path('entity.node.canonical', {node: document.id, collection: collection.id}) }}"
+            {{ node.id == document.id ? 'class="active" aria-current="true"' }}
+          ><span class="document-title">{{ document.title.value }}</span></a>
+          {% if item.children %}
+            {{ _self.table_of_contents(item.children, collection, node) }}
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ol>
+  {% endif %}
+{% endmacro %}
+
 <article{{ attributes }}>
   <ul class="tabs nav" id="document-tabs" role="tablist">
     <li>
@@ -90,6 +108,25 @@
         </h1>
       {% endif %}
       {{ title_suffix }}
+
+      {% if os2loop_documents_collection_tree|default(false) %}
+        <fieldset>
+          <legend>{{ 'Documents in collection'|trans }}
+            <a href="{{ path('entity.node.canonical', {node: os2loop_documents_collection.id}) }}">{{ os2loop_documents_collection.title.value }}</a>
+          </legend>
+          {{ _self.table_of_contents(os2loop_documents_collection_tree, os2loop_documents_collection, node) }}
+        </fieldset>
+      {% elseif os2loop_documents_collections|default(false) %}
+        <fieldset>
+          <legend>{{ 'Document is part of these collections'|trans }}</legend>
+          <ol>
+            {% for collection in os2loop_documents_collections %}
+              <li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
+            {% endfor %}
+          </ol>
+        </fieldset>
+      {% endif %}
+
       <div{{ content_attributes }}>
         {{ content.os2loop_shared_subject }}
         {{ content.os2loop_documents_document_body }}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -91,63 +91,60 @@
 {% endmacro %}
 
 <article{{ attributes }}>
-  <ul class="tabs nav" id="document-tabs" role="tablist">
-    <li>
-      <a class="tab active" id="document-tab" data-toggle="tab" href="#document" role="tab" aria-controls="document" aria-selected="true">Document</a>
-    </li>
-    <li>
-      <a class="tab" id="about-document-tab" data-toggle="tab" href="#about-document" role="tab" aria-controls="about-document" aria-selected="false">About document</a>
-    </li>
-  </ul>
-  <div class="tab-content" id="document-tabs-content">
-    <div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
-      {{ title_prefix }}
-      {% if label  %}
-        <h1{{ title_attributes }}>
-          {{ label }}
-        </h1>
-      {% endif %}
-      {{ title_suffix }}
-
-      {% if os2loop_documents_collection_tree|default(false) %}
-        <fieldset>
-          <legend>{{ 'Documents in collection'|trans }}
-            <a href="{{ path('entity.node.canonical', {node: os2loop_documents_collection.id}) }}">{{ os2loop_documents_collection.title.value }}</a>
-          </legend>
-          {{ _self.table_of_contents(os2loop_documents_collection_tree, os2loop_documents_collection, node) }}
-        </fieldset>
-      {% elseif os2loop_documents_collections|default(false) %}
-        <fieldset>
-          <legend>{{ 'Document is part of these collections'|trans }}</legend>
-          <ol>
-            {% for collection in os2loop_documents_collections %}
-              <li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
-            {% endfor %}
-          </ol>
-        </fieldset>
-      {% endif %}
-
-      <div{{ content_attributes }}>
-        {{ content.os2loop_shared_subject }}
-        {{ content.os2loop_documents_document_body }}
-        {{ content.os2loop_documents_document_conte }}
-      </div>
-    </div>
-    <div class="tab-pane" id="about-document" role="tabpanel" aria-labelledby="about-document-tab">
-      {{ title_prefix }}
-      {% if label  %}
-        <h1{{ title_attributes }}>
-          Om dokumentet
-        </h1>
-      {% endif %}
-      {{ title_suffix }}
-      {{ content.os2loop_documents_document_autho }}
-      <div{{ content_attributes.addClass("bg-secondary-loop") }}>
-        {{ content.os2loop_shared_tags }}
-        {{ content.os2loop_shared_subject }}
-        {{ content.os2loop_shared_profession }}
+	<ul class="tabs nav" id="document-tabs" role="tablist">
+		<li>
+			<a class="tab active" id="document-tab" data-toggle="tab" href="#document" role="tab" aria-controls="document" aria-selected="true">Document</a>
+		</li>
+		<li>
+			<a class="tab" id="about-document-tab" data-toggle="tab" href="#about-document" role="tab" aria-controls="about-document" aria-selected="false">About document</a>
+		</li>
+	</ul>
+	<div class="tab-content" id="document-tabs-content">
+		<div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
+			{{ title_prefix }}
+			{% if label  %}
+				<h1{{ title_attributes }}>
+					{{ label }}
+				</h1>
+			{% endif %}
+			{{ title_suffix }}
+			{% if os2loop_documents_collection_tree|default(false) %}
+				<fieldset>
+					<legend>{{ 'Documents in collection'|trans }}
+						<a href="{{ path('entity.node.canonical', {node: os2loop_documents_collection.id}) }}">{{ os2loop_documents_collection.title.value }}</a>
+					</legend>
+					{{ _self.table_of_contents(os2loop_documents_collection_tree, os2loop_documents_collection, node) }}
+				</fieldset>
+			{% elseif os2loop_documents_collections|default(false) %}
+				<fieldset>
+					<legend>{{ 'Document is part of these collections'|trans }}</legend>
+					<ol>
+						{% for collection in os2loop_documents_collections %}
+							<li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
+						{% endfor %}
+					</ol>
+				</fieldset>
+			{% endif %}
+			<div{{ content_attributes }}>
+				{{ content.os2loop_shared_subject }}
+				{{ content.os2loop_documents_document_conte }}
+			</div>
+		</div>
+		<div class="tab-pane" id="about-document" role="tabpanel" aria-labelledby="about-document-tab">
+			{{ title_prefix }}
+			{% if label  %}
+				<h1{{ title_attributes }}>
+					Om dokumentet
+				</h1>
+			{% endif %}
+			{{ title_suffix }}
+			{{ content.os2loop_documents_document_autho }}
+			<div{{ content_attributes.addClass("bg-secondary-loop") }}>
+				{{ content.os2loop_shared_tags }}
+				{{ content.os2loop_shared_subject }}
+				{{ content.os2loop_shared_profession }}
         {{ content.flag_os2loop_favourite }}
-      </div>
-    </div>
-  </div>
+			</div>
+		</div>
+	</div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -147,4 +147,7 @@
 			</div>
 		</div>
 	</div>
+
+	{# @todo design #}
+	<a class="btn btn-secondary" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print document (PDF)'|t }}</a>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -149,5 +149,5 @@
 	</div>
 
 	{# @todo design #}
-	<a class="btn btn-secondary" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print document (PDF)'|t }}</a>
+	<a class="btn btn-secondary btn-print" href="{{ path('entity_print.view', {export_type: 'pdf', entity_type: 'node', entity_id: node.id}) }}">{{ 'Print document (PDF)'|t }}</a>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/webpack.config.js
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/webpack.config.js
@@ -25,6 +25,7 @@ Encore
      * and one CSS file (e.g. app.css) if your JavaScript imports CSS.
      */
     .addEntry('app', './assets/app.js')
+    .addEntry('pdf', './assets/pdf/pdf.scss')
 
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     //.splitEntryChunks()


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-832

- LOOP-832: Added UI for adding documents to a collection
- LOOP-832: Cleaned up and added toc to view of documents and collections
- LOOP-832: Added cache busting when updating document and collections
- LOOP-832: Added entity print module
- LOOP-832: Cleaned up template
- LOOP-832: Updated composer.lock
- LOOP-832: Added print (PDF) button

# New commits (since last review)

- LOOP-832: Added phpwkhtmltopdf for printing to pdf
- LOOP-832: Added Print collection (PDF) button
- LOOP-832: Added PDF display and templates for documents and collections
- LOOP-832: Added provisionary styling for PDF
