### PR TITLE
LOOP-832: Cleaned up whitespace in templates

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/comment--os2loop-post-comments.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/comment--os2loop-post-comments.html.twig
@@ -74,46 +74,46 @@
 %}
 
 <article{{ attributes.addClass('js-comment os2loop-comment') }}>
-	{#
-		Hide the "new" indicator by default, let a piece of JavaScript ask the
-		server which comments are new for the user. Rendering the final "new"
-		indicator here would break the render cache.
-	#}
-	<div class="d-flex align-items-center">
-		<div class="icon-container">
-			{{ content.flag_os2loop_upvote_upvote_button }}
-			{{ content.links }}
-		</div>
-		{{ title_prefix }}
-		{% if label %}
-			<h1{{ title_attributes }}>
-				{{ label }}
-			</h1>
-		{% endif %}
-		{{ title_suffix }}
-		<div class="user">
-			<i class="bi bi-file-person"></i>
-			{# TODO fix image #}
-			<div class="col-md">
-				<div>
-					{{ author }}
-					{{ created }}
-				</div>
-				<div>metadata</div>
-				{# TODO fix metadata #}
-			</div>
-		</div>
-	</div>
-	{#
-		Indicate the semantic relationship between parent and child comments for
-		accessibility. The list is difficult to navigate in a screen reader
-		without this information.
-	#}
-	<div{{ content_attributes.addClass(background_class) }}>
-		{% if parent %}
-			<p class="visually-hidden">{{ parent }}</p>
-		{% endif %}
-		{{ content.os2loop_post_comment }}
-		<div>{{ content.flag_os2loop_upvote_correct_answer }}</div>
-	</div>
+  {#
+    Hide the "new" indicator by default, let a piece of JavaScript ask the
+    server which comments are new for the user. Rendering the final "new"
+    indicator here would break the render cache.
+  #}
+  <div class="d-flex align-items-center">
+    <div class="icon-container">
+      {{ content.flag_os2loop_upvote_upvote_button }}
+      {{ content.links }}
+    </div>
+    {{ title_prefix }}
+    {% if label %}
+      <h1{{ title_attributes }}>
+        {{ label }}
+      </h1>
+    {% endif %}
+    {{ title_suffix }}
+    <div class="user">
+      <i class="bi bi-file-person"></i>
+      {# TODO fix image #}
+      <div class="col-md">
+        <div>
+          {{ author }}
+          {{ created }}
+        </div>
+        <div>metadata</div>
+        {# TODO fix metadata #}
+      </div>
+    </div>
+  </div>
+  {#
+    Indicate the semantic relationship between parent and child comments for
+    accessibility. The list is difficult to navigate in a screen reader
+    without this information.
+  #}
+  <div{{ content_attributes.addClass(background_class) }}>
+    {% if parent %}
+      <p class="visually-hidden">{{ parent }}</p>
+    {% endif %}
+    {{ content.os2loop_post_comment }}
+    <div>{{ content.flag_os2loop_upvote_correct_answer }}</div>
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/comment--os2loop-question-answers.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/comment--os2loop-question-answers.html.twig
@@ -73,46 +73,46 @@
 %}
 
 <article{{ attributes.addClass('js-comment os2loop-comment') }}>
-	{#
-		Hide the "new" indicator by default, let a piece of JavaScript ask the
-		server which comments are new for the user. Rendering the final "new"
-		indicator here would break the render cache.
-	#}
-	<div class="d-flex align-items-center">
-		<div class="icon-container">
-			{{ content.flag_os2loop_upvote_upvote_button }}
-			{{ content.links }}
-		</div>
-		{{ title_prefix }}
-		{% if label %}
-			<h1{{ title_attributes }}>
-				{{ label }}
-			</h1>
-		{% endif %}
-		{{ title_suffix }}
-		<div class="user">
-			<i class="bi bi-file-person"></i>
-			{# TODO fix image #}
-			<div class="col-md">
-				<div>
-					{{ author }}
-					{{ created }}
-				</div>
-				<div>metadata</div>
-				{# TODO fix metadata #}
-			</div>
-		</div>
-	</div>
-	{#
-		Indicate the semantic relationship between parent and child comments for
-		accessibility. The list is difficult to navigate in a screen reader
-		without this information.
-	#}
-	<div{{ content_attributes.addClass(background_class) }}>
-		{% if parent %}
-			<p class="visually-hidden">{{ parent }}</p>
-		{% endif %}
-		{{ content.os2loop_question_answer }}
-		<div>{{ content.flag_os2loop_upvote_correct_answer }}</div>
-	</div>
+  {#
+    Hide the "new" indicator by default, let a piece of JavaScript ask the
+    server which comments are new for the user. Rendering the final "new"
+    indicator here would break the render cache.
+  #}
+  <div class="d-flex align-items-center">
+    <div class="icon-container">
+      {{ content.flag_os2loop_upvote_upvote_button }}
+      {{ content.links }}
+    </div>
+    {{ title_prefix }}
+    {% if label %}
+      <h1{{ title_attributes }}>
+        {{ label }}
+      </h1>
+    {% endif %}
+    {{ title_suffix }}
+    <div class="user">
+      <i class="bi bi-file-person"></i>
+      {# TODO fix image #}
+      <div class="col-md">
+        <div>
+          {{ author }}
+          {{ created }}
+        </div>
+        <div>metadata</div>
+        {# TODO fix metadata #}
+      </div>
+    </div>
+  </div>
+  {#
+    Indicate the semantic relationship between parent and child comments for
+    accessibility. The list is difficult to navigate in a screen reader
+    without this information.
+  #}
+  <div{{ content_attributes.addClass(background_class) }}>
+    {% if parent %}
+      <p class="visually-hidden">{{ parent }}</p>
+    {% endif %}
+    {{ content.os2loop_question_answer }}
+    <div>{{ content.flag_os2loop_upvote_correct_answer }}</div>
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/field--node--os2loop-question-answers.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/field--node--os2loop-question-answers.html.twig
@@ -27,27 +27,27 @@
  */
 #}
 <section{{ attributes }}>
-	{% if comments and not label_hidden %}
-		{{ title_prefix }}
-		<h2{{ title_attributes }}>{{ label }}</h2>
-		{{ title_suffix }}
-	{% endif %}
-	{{ comments }}
-	{% if comment_form %}
-		<h2{{ content_attributes }}>{{ 'Add new comment'|t }}</h2>
-		<div class="user">
-			<i class="bi bi-file-person"></i>
-			{# TODO fix image #}
-			<div class="col-md">
-				<div>
-					{{ user.displayname }}
-				</div>
-				<div>metadata</div>
-				{# TODO fix metadata #}
-			</div>
-		</div>
-		<div class="bg-secondary-loop comment-reply">
-			{{ comment_form }}
-		</div>
-	{% endif %}
+  {% if comments and not label_hidden %}
+    {{ title_prefix }}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+    {{ title_suffix }}
+  {% endif %}
+  {{ comments }}
+  {% if comment_form %}
+    <h2{{ content_attributes }}>{{ 'Add new comment'|t }}</h2>
+    <div class="user">
+      <i class="bi bi-file-person"></i>
+      {# TODO fix image #}
+      <div class="col-md">
+        <div>
+          {{ user.displayname }}
+        </div>
+        <div>metadata</div>
+        {# TODO fix metadata #}
+      </div>
+    </div>
+    <div class="bg-secondary-loop comment-reply">
+      {{ comment_form }}
+    </div>
+  {% endif %}
 </section>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/field--os2loop-post-comments.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/field--os2loop-post-comments.html.twig
@@ -35,17 +35,17 @@
   {{ comments }}
   {% if comment_form %}
     <h2{{ content_attributes }}>{{ 'Add new comment'|t }}</h2>
-    		<div class="user">
-			<i class="bi bi-file-person"></i>
-			{# TODO fix image #}
-			<div class="col-md">
-				<div>
-				  {{ user.displayname }}
-				</div>
-				<div>metadata</div>
-				{# TODO fix metadata #}
-			</div>
-		</div>
+        <div class="user">
+      <i class="bi bi-file-person"></i>
+      {# TODO fix image #}
+      <div class="col-md">
+        <div>
+          {{ user.displayname }}
+        </div>
+        <div>metadata</div>
+        {# TODO fix metadata #}
+      </div>
+    </div>
     <div class="bg-secondary-loop comment-reply">
       {{ comment_form }}
     </div>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/links--comment.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/links--comment.html.twig
@@ -34,12 +34,12 @@
  */
 #}
 {% if links -%}
-		{%- for item in links -%}
-			<li{{ item.attributes }} class="icon {{ item.link['#title']|lower }}">
-				{%- if item.link -%}
-					<a href={{ item.link['#url'] }} aria-label={{ item.link['#title'] }}>
-					</a>
-				{%- endif -%}
-			</li>
-		{%- endfor -%}
+    {%- for item in links -%}
+      <li{{ item.attributes }} class="icon {{ item.link['#title']|lower }}">
+        {%- if item.link -%}
+          <a href={{ item.link['#url'] }} aria-label={{ item.link['#title'] }}>
+          </a>
+        {%- endif -%}
+      </li>
+    {%- endfor -%}
 {%- endif %}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -73,43 +73,43 @@
  */
 #}
 <article{{ attributes }}>
-	<ul class="tabs nav" id="document-tabs" role="tablist">
-		<li>
-			<a class="tab active" id="document-tab" data-toggle="tab" href="#document" role="tab" aria-controls="document" aria-selected="true">Document</a>
-		</li>
-		<li>
-			<a class="tab" id="about-document-tab" data-toggle="tab" href="#about-document" role="tab" aria-controls="about-document" aria-selected="false">About document</a>
-		</li>
-	</ul>
-	<div class="tab-content" id="document-tabs-content">
-		<div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
-			{{ title_prefix }}
-			{% if label  %}
-				<h1{{ title_attributes }}>
-					{{ label }}
-				</h1>
-			{% endif %}
-			{{ title_suffix }}
-			<div{{ content_attributes }}>
-				{{ content.os2loop_shared_subject }}
-				{{ content.os2loop_documents_document_conte }}
-			</div>
-		</div>
-		<div class="tab-pane" id="about-document" role="tabpanel" aria-labelledby="about-document-tab">
-			{{ title_prefix }}
-			{% if label  %}
-				<h1{{ title_attributes }}>
-					Om dokumentet
-				</h1>
-			{% endif %}
-			{{ title_suffix }}
-			{{ content.os2loop_documents_document_autho }}
-			<div{{ content_attributes.addClass("bg-secondary-loop") }}>
-				{{ content.os2loop_shared_tags }}
-				{{ content.os2loop_shared_subject }}
-				{{ content.os2loop_shared_profession }}
+  <ul class="tabs nav" id="document-tabs" role="tablist">
+    <li>
+      <a class="tab active" id="document-tab" data-toggle="tab" href="#document" role="tab" aria-controls="document" aria-selected="true">Document</a>
+    </li>
+    <li>
+      <a class="tab" id="about-document-tab" data-toggle="tab" href="#about-document" role="tab" aria-controls="about-document" aria-selected="false">About document</a>
+    </li>
+  </ul>
+  <div class="tab-content" id="document-tabs-content">
+    <div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
+      {{ title_prefix }}
+      {% if label  %}
+        <h1{{ title_attributes }}>
+          {{ label }}
+        </h1>
+      {% endif %}
+      {{ title_suffix }}
+      <div{{ content_attributes }}>
+        {{ content.os2loop_shared_subject }}
+        {{ content.os2loop_documents_document_conte }}
+      </div>
+    </div>
+    <div class="tab-pane" id="about-document" role="tabpanel" aria-labelledby="about-document-tab">
+      {{ title_prefix }}
+      {% if label  %}
+        <h1{{ title_attributes }}>
+          Om dokumentet
+        </h1>
+      {% endif %}
+      {{ title_suffix }}
+      {{ content.os2loop_documents_document_autho }}
+      <div{{ content_attributes.addClass("bg-secondary-loop") }}>
+        {{ content.os2loop_shared_tags }}
+        {{ content.os2loop_shared_subject }}
+        {{ content.os2loop_shared_profession }}
         {{ content.flag_os2loop_favourite }}
-			</div>
-		</div>
-	</div>
+      </div>
+    </div>
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-external.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-external.html.twig
@@ -73,25 +73,25 @@
  */
 #}
 <article{{ attributes.addClass("os2loop-content") }}>
-	{{ title_prefix }}
-	{% if label %}
-		<h1{{ title_attributes }}>
-			{{ label }}
-		</h1>
-	{% endif %}
-	{{ title_suffix }}
-	<div class="user">
-		<i class="bi bi-file-person"></i>
-		{# TODO fix image #}
-		<div class="col-md">
-			<div>{{ author_name }}
-				{{ date }}</div>
-			<div>metadata</div>
-			{# TODO fix metadata #}
-		</div>
-	</div>
+  {{ title_prefix }}
+  {% if label %}
+    <h1{{ title_attributes }}>
+      {{ label }}
+    </h1>
+  {% endif %}
+  {{ title_suffix }}
+  <div class="user">
+    <i class="bi bi-file-person"></i>
+    {# TODO fix image #}
+    <div class="col-md">
+      <div>{{ author_name }}
+        {{ date }}</div>
+      <div>metadata</div>
+      {# TODO fix metadata #}
+    </div>
+  </div>
 
-	<div{{ content_attributes.addClass("bg-secondary-loop") }}>
-		{{ content|without('os2loop_shared_profession', 'os2loop_shared_tags', 'os2loop_shared_subject') }}
-	</div>
+  <div{{ content_attributes.addClass("bg-secondary-loop") }}>
+    {{ content|without('os2loop_shared_profession', 'os2loop_shared_tags', 'os2loop_shared_subject') }}
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-page.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-page.html.twig
@@ -73,14 +73,14 @@
  */
 #}
 <article{{ attributes.addClass("os2loop-content") }}>
-	{{ title_prefix }}
-	{% if label %}
-		<h1{{ title_attributes }}>
-			{{ label }}
-		</h1>
-	{% endif %}
-	{{ title_suffix }}
-	<div{{ content_attributes.addClass("bg-secondary-loop") }}>
-		{{ content }}
-	</div>
+  {{ title_prefix }}
+  {% if label %}
+    <h1{{ title_attributes }}>
+      {{ label }}
+    </h1>
+  {% endif %}
+  {{ title_suffix }}
+  <div{{ content_attributes.addClass("bg-secondary-loop") }}>
+    {{ content }}
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-post.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-post.html.twig
@@ -71,36 +71,36 @@
  */
 #}
 <article{{ attributes.addClass("os2loop-content os2loop-post") }}>
-	<div>
-		{{ title_prefix }}
-		{% if label %}
-			<h1{{ title_attributes }}>
-				{{ label }}
-			</h1>
-		{% endif %}
-		{{ title_suffix }}
-		<div class="user">
-			{% if author_picture %}
-				{{ author_picture }}
-			{% else %}
-				<i class="bi bi-file-person"></i>
-			{% endif %}
-			{# TODO fix image #}
-			<div class="col-md">
-				<div>{{ author_name }}
-					{{ date }}</div>
-				<div>metadata</div>
-				{# TODO fix metadata #}
-			</div>
-		</div>
-		<div{{ content_attributes.addClass('bg-secondary-loop') }}>
-			{{ content.os2loop_post_content }}
-			{{ content.os2loop_shared_tags }}
-			{{ content.os2loop_shared_subject }}
-			{{ content.os2loop_shared_profession }}
-			{{ content.os2loop_post_file }}
+  <div>
+    {{ title_prefix }}
+    {% if label %}
+      <h1{{ title_attributes }}>
+        {{ label }}
+      </h1>
+    {% endif %}
+    {{ title_suffix }}
+    <div class="user">
+      {% if author_picture %}
+        {{ author_picture }}
+      {% else %}
+        <i class="bi bi-file-person"></i>
+      {% endif %}
+      {# TODO fix image #}
+      <div class="col-md">
+        <div>{{ author_name }}
+          {{ date }}</div>
+        <div>metadata</div>
+        {# TODO fix metadata #}
+      </div>
+    </div>
+    <div{{ content_attributes.addClass('bg-secondary-loop') }}>
+      {{ content.os2loop_post_content }}
+      {{ content.os2loop_shared_tags }}
+      {{ content.os2loop_shared_subject }}
+      {{ content.os2loop_shared_profession }}
+      {{ content.os2loop_post_file }}
       {{ content.flag_os2loop_favourite }}
-		</div>
-		{{ content.os2loop_post_comments }}
-	</div>
+    </div>
+    {{ content.os2loop_post_comments }}
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-question.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-question.html.twig
@@ -71,36 +71,36 @@
  */
 #}
 <article{{ attributes.addClass("os2loop-content os2loop-question") }}>
-	<div>
-		{{ title_prefix }}
-		{% if label %}
-			<h1{{ title_attributes }}>
-				{{ label }}
-			</h1>
-		{% endif %}
-		{{ title_suffix }}
-		<div class="user">
-			{% if author_picture %}
-				{{ author_picture }}
-			{% else %}
-				<i class="bi bi-file-person"></i>
-			{% endif %}
-			{# TODO fix image #}
-			<div class="col-md">
-				<div>{{ author_name }}
-					{{ date }}</div>
-				<div>metadata</div>
-				{# TODO fix metadata #}
-			</div>
-		</div>
-		<div{{ content_attributes.addClass('bg-secondary-loop') }}>
-			{{ content.os2loop_question_content }}
-			{{ content.os2loop_shared_tags }}
-			{{ content.os2loop_shared_subject }}
-			{{ content.os2loop_shared_profession }}
-			{{ content.os2loop_question_file }}
+  <div>
+    {{ title_prefix }}
+    {% if label %}
+      <h1{{ title_attributes }}>
+        {{ label }}
+      </h1>
+    {% endif %}
+    {{ title_suffix }}
+    <div class="user">
+      {% if author_picture %}
+        {{ author_picture }}
+      {% else %}
+        <i class="bi bi-file-person"></i>
+      {% endif %}
+      {# TODO fix image #}
+      <div class="col-md">
+        <div>{{ author_name }}
+          {{ date }}</div>
+        <div>metadata</div>
+        {# TODO fix metadata #}
+      </div>
+    </div>
+    <div{{ content_attributes.addClass('bg-secondary-loop') }}>
+      {{ content.os2loop_question_content }}
+      {{ content.os2loop_shared_tags }}
+      {{ content.os2loop_shared_subject }}
+      {{ content.os2loop_shared_profession }}
+      {{ content.os2loop_question_file }}
       {{ content.flag_os2loop_favourite }}
-		</div>
-		{{ content.os2loop_question_answers }}
-	</div>
+    </div>
+    {{ content.os2loop_question_answers }}
+  </div>
 </article>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu-local-task.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu-local-task.html.twig
@@ -15,10 +15,9 @@
  */
 #}
 {% set classes = [
-		"icon",
+    "icon",
     is_active ? 'active'
   ]
 %}
 
 <li {{ attributes.addClass(classes) }}>{{ link("", link["#url"]) }}</li>
-


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-832

Cleans up whitespace in templates to match `.editorconfig` settings.
