### PR TITLE
LOOP-800: added comments and fixed errors in flaghelper

### DIFF
--- a/web/profiles/custom/os2loop/modules/os2loop_upvote/src/Helper/FlagHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_upvote/src/Helper/FlagHelper.php
@@ -35,12 +35,12 @@ class FlagHelper {
    * If there is no "correct answer", the top comment will be the most upvoted.
    */
   public function preprocessField(array &$variables) {
-    // An array of the two comment fields.
+    // An array of the two relevant comment fields.
     $field = ['os2loop_question_answers', 'os2loop_post_comments'];
     if (in_array($variables['field_name'], $field)) {
       foreach ($variables['comments'] as $comment) {
         if (isset($comment['#comment'])) {
-          // Get flags for this comment: correct answers and upvote.
+          // Get flags for this comment: correct answer and upvote.
           $comment_flag_counts = $this->flagCountManager->getEntityFlagCounts($comment['#comment']);
           // If comment is marked as correct answer, it is the top comment.
           if (isset($comment_flag_counts['os2loop_upvote_correct_answer'])) {
@@ -57,6 +57,7 @@ class FlagHelper {
               $comment_upvotes = intval($comment_flag_counts['os2loop_upvote_upvote_button']);
 
               if ($comment_upvotes > $upvoted_comment_upvotes) {
+                // If current comment has more upvotes make it upvoted comment.
                 $upvoted_comment = $comment;
               }
             }
@@ -64,10 +65,11 @@ class FlagHelper {
         }
       }
       if (isset($upvoted_comment) || isset($correct_answer)) {
+        // Correct answer wins.
         $top_comment = isset($correct_answer) ? $correct_answer : $upvoted_comment;
         // Set a top value, used to add a styling class.
         $top_comment['#top'] = TRUE;
-        // Threaded: false, to avoid indentation.
+        // Threaded: false, to avoid indentation (styling).
         $top_comment['#comment_threaded'] = FALSE;
         // Add to top of comment list.
         array_unshift($variables['comments'], $top_comment);

--- a/web/profiles/custom/os2loop/modules/os2loop_upvote/src/Helper/FlagHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_upvote/src/Helper/FlagHelper.php
@@ -64,15 +64,23 @@ class FlagHelper {
           }
         }
       }
-      if (isset($upvoted_comment) || isset($correct_answer)) {
-        // Correct answer wins.
-        $top_comment = isset($correct_answer) ? $correct_answer : $upvoted_comment;
+
+      if (isset($correct_answer)) {
         // Set a top value, used to add a styling class.
-        $top_comment['#top'] = TRUE;
+        $correct_answer['#top'] = TRUE;
         // Threaded: false, to avoid indentation (styling).
-        $top_comment['#comment_threaded'] = FALSE;
+        $correct_answer['#comment_threaded'] = FALSE;
         // Add to top of comment list.
-        array_unshift($variables['comments'], $top_comment);
+        array_unshift($variables['comments'], $correct_answer);
+      }
+      elseif (isset($upvoted_comment)) {
+        // Set a top value, used to add a styling class.
+        $upvoted_comment['#top'] = TRUE;
+        // Threaded: false, to avoid indentation (styling).
+        $upvoted_comment['#comment_threaded'] = FALSE;
+        // Add to top of comment list.
+        array_unshift($variables['comments'], $upvoted_comment);
+
       }
     }
   }

--- a/web/profiles/custom/os2loop/modules/os2loop_upvote/src/Helper/FlagHelper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_upvote/src/Helper/FlagHelper.php
@@ -80,7 +80,6 @@ class FlagHelper {
         $upvoted_comment['#comment_threaded'] = FALSE;
         // Add to top of comment list.
         array_unshift($variables['comments'], $upvoted_comment);
-
       }
     }
   }


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-800

"I os2loop_upvote modulet ligger FlagHelper-klassen med preprocessField() metoden. Denne metode har en ret høj kodekompleksitet med mange betingelser og løkker nested i hinanden. Dette nedsætter læsbarheden og øger risikoen for fejl i funktionaliteten, samt øger risikoen for at der ved videreudvikling introduceres nye fejl eller utilsigtet, ændret logik.
Der er muligvis allerede en fejl i metoden idet nedenstående linje muligvis kan udføres uden der er identificeret / sat en $top_comment. Om det i praksis er et problem skal jeg ikke kunne sige, men det illustrerer meget fint hvorfor det kan være en idé at arbejde med metoden så den bliver mere læsbar.

Samlet set er metoden dog ikke omfattende hvilket afbøder risikoen en smule."