### PR TITLE
LOOP-897: Fixed styling of comment buttons

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/icons.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/icons.scss
@@ -14,6 +14,7 @@
     border-radius: 2px;
     color: $white;
 
+    &.comment-edit,
     &.edit {
       @include link-icon("\f4ca", $edit, $dark-edit);
     }
@@ -42,18 +43,22 @@
       }
     }
 
+    &.comment-share,
     &.share {
       @include link-icon("\f52e");
     }
 
+    &.comment-flag,
     &.flag {
       @include link-icon("\f3cc");
     }
 
+    &.comment-reply,
     &.reply {
       @include link-icon("\f51f");
     }
 
+    &.comment-delete,
     &.delete {
       @include link-icon("\f5de", $delete, $dark-delete);
     }

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/links--comment.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/links--comment.html.twig
@@ -34,10 +34,10 @@
  */
 #}
 {% if links -%}
-    {%- for item in links -%}
-      <li{{ item.attributes }} class="icon {{ item.link['#title']|lower }}">
+    {%- for key, item in links -%}
+      <li{{ item.attributes.addClass('icon', key) }}>
         {%- if item.link -%}
-          <a href={{ item.link['#url'] }} aria-label={{ item.link['#title'] }}>
+          <a href={{ item.link['#url'] }} aria-label={{ item.text }}>
           </a>
         {%- endif -%}
       </li>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-897

Fixes issue with translated css classes.

With Danish as site language:

(before)
<img width="1129" alt="Screen Shot 2021-05-13 at 12 47 10" src="https://user-images.githubusercontent.com/11267554/118116092-1e7a9000-b3ea-11eb-8fb0-77caa0f6b397.png">

(after)
<img width="1129" alt="Screen Shot 2021-05-13 at 12 50 03" src="https://user-images.githubusercontent.com/11267554/118116104-220e1700-b3ea-11eb-93ac-78d01363c950.png">
