### PR TITLE
LOOP-898: Remove user language from detection

### DIFF
--- a/config/sync/language.types.yml
+++ b/config/sync/language.types.yml
@@ -14,7 +14,6 @@ negotiation:
       language-url-fallback: 1
   language_interface:
     enabled:
-      language-user: -4
       language-selected: 12
     method_weights:
       language-user-admin: -10


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-898

Users should not be able to select ui language. This is removes the check for user language when detecting the language.
