### PR TITLE
LOOP-895: Search field styling

### DIFF
--- a/web/profiles/custom/os2loop/modules/os2loop_section_page/modules/os2loop_section_page_fixtures/src/Fixture/FrontPageFixture.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_section_page/modules/os2loop_section_page_fixtures/src/Fixture/FrontPageFixture.php
@@ -46,9 +46,15 @@ class FrontPageFixture extends AbstractFixture implements FixtureGroupInterface 
     BODY,
         'format' => 'os2loop_section_page',
       ],
-      'os2loop_section_page_view' => [
-        'target_id' => 'os2loop_section_page_most_viewed',
-        'display_id' => 'block_1',
+    ]);
+    $paragraph->save();
+    $page->get('os2loop_section_page_paragraph')->appendItem($paragraph);
+
+    $paragraph = Paragraph::create([
+      'type' => 'os2loop_section_page_views_refer',
+      'os2loop_section_page_view_header' => 'Search',
+      'os2loop_section_page_block' => [
+        'plugin_id' => 'views_exposed_filter_block:os2loop_search_db-page_search_form',
       ],
     ]);
     $paragraph->save();

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/search.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/search.scss
@@ -38,3 +38,12 @@
     }
   }
 }
+
+// @see https://blog.maximerouiller.com/post/remove-the-x-from-internet-explorer-and-chrome-input-type-search/
+// clears the 'X' from Chrome
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+  display: none;
+}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/yarn.lock
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/yarn.lock
@@ -4515,11 +4515,6 @@ postcss@^8.2.6:
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-
 pretty-error@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-3.0.3.tgz#57f4b16aebcadbd681db2c002ae0f95bf87b24cf"


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-895

Hides search box clear symbol from chromium browsers.
