### PR TITLE
LOOP-908: Removed “Promote” and “Sticky” from node forms

### DIFF
--- a/config/sync/core.entity_form_display.node.os2loop_documents_collection.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_documents_collection.default.yml
@@ -81,25 +81,11 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -122,3 +108,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_form_display.node.os2loop_documents_document.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_documents_document.default.yml
@@ -104,25 +104,11 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -145,3 +131,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_form_display.node.os2loop_external.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_external.default.yml
@@ -99,25 +99,11 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -140,3 +126,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_form_display.node.os2loop_page.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_page.default.yml
@@ -37,25 +37,11 @@ content:
       media_types: {  }
     third_party_settings: {  }
     region: content
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -78,3 +64,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_form_display.node.os2loop_post.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_post.default.yml
@@ -106,25 +106,11 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -147,3 +133,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_form_display.node.os2loop_question.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_question.default.yml
@@ -106,25 +106,11 @@ content:
     type: autocomplete_deluxe
     region: content
     weight: 8
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -147,3 +133,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true

--- a/config/sync/core.entity_form_display.node.os2loop_section_page.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_section_page.default.yml
@@ -30,25 +30,11 @@ content:
       default_paragraph_type: _none
     third_party_settings: {  }
     region: content
-  promote:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 3
-    region: content
-    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 5
-    region: content
-    third_party_settings: {  }
-  sticky:
-    type: boolean_checkbox
-    settings:
-      display_label: true
-    weight: 4
     region: content
     third_party_settings: {  }
   title:
@@ -71,3 +57,5 @@ content:
     third_party_settings: {  }
 hidden:
   langcode: true
+  promote: true
+  sticky: true


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-908

Removes fields that are not used from the node edit form.
