### PR TITLE
Fixed service ids

### DIFF
--- a/web/profiles/custom/os2loop/modules/os2loop_flag_content/os2loop_flag_content.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_flag_content/os2loop_flag_content.services.yml
@@ -3,8 +3,9 @@ services:
     class: Drupal\os2loop_flag_content\Services\ConfigService
     arguments:
       - '@config.factory'
+
   os2loop_flag_content.mail_helper:
     class: Drupal\os2loop_flag_content\Helper\MailHelper
     arguments:
       - '@token'
-      - '@Drupal\os2loop_settings\Settings'
+      - '@os2loop_settings.settings'

--- a/web/profiles/custom/os2loop/modules/os2loop_lists/os2loop_lists.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_lists/os2loop_lists.services.yml
@@ -1,5 +1,5 @@
 services:
-  Drupal\os2loop_lists\Helper\Helper:
+  os2loop_lists.helper:
     class: Drupal\os2loop_lists\Helper\Helper
     arguments:
       - '@entity_type.manager'

--- a/web/profiles/custom/os2loop/modules/os2loop_lists/src/Plugin/Block/Os2loopListsExpertBlock.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_lists/src/Plugin/Block/Os2loopListsExpertBlock.php
@@ -60,7 +60,7 @@ class Os2loopListsExpertBlock extends BlockBase implements ContainerFactoryPlugi
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get(Helper::class)
+      $container->get('os2loop_lists.helper')
     );
   }
 

--- a/web/profiles/custom/os2loop/modules/os2loop_lists/src/Plugin/Block/Os2loopListsProfessionBlock.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_lists/src/Plugin/Block/Os2loopListsProfessionBlock.php
@@ -60,7 +60,7 @@ class Os2loopListsProfessionBlock extends BlockBase implements ContainerFactoryP
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get(Helper::class)
+      $container->get('os2loop_lists.helper')
     );
   }
 

--- a/web/profiles/custom/os2loop/modules/os2loop_media/os2loop_media.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_media/os2loop_media.module
@@ -7,11 +7,10 @@
 
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
-use Drupal\os2loop_media\Helper\Helper;
 
 /**
  * Implements hook_views_query_alter().
  */
 function os2loop_media_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  Drupal::service(Helper::class)->queryAlter($view, $query);
+  Drupal::service('os2loop_media.helper')->queryAlter($view, $query);
 }

--- a/web/profiles/custom/os2loop/modules/os2loop_media/os2loop_media.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_media/os2loop_media.services.yml
@@ -1,5 +1,5 @@
 services:
-  Drupal\os2loop_media\Helper\Helper:
+  os2loop_media.helper:
     class: Drupal\os2loop_media\Helper\Helper
     arguments:
       - '@current_user'

--- a/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\os2loop_question\Helper\Helper;
 
 /**
  * Implements hook_help().
@@ -29,5 +28,5 @@ function os2loop_question_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_form_alter().
  */
 function os2loop_question_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
-  Drupal::service(Helper::class)->alterForm($form, $form_state, $form_id);
+  Drupal::service('os2loop_question.helper')->alterForm($form, $form_state, $form_id);
 }

--- a/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.services.yml
@@ -1,5 +1,5 @@
 services:
-  Drupal\os2loop_question\Helper\Helper:
+  os2loop_question.helper:
     class: Drupal\os2loop_question\Helper\Helper
     arguments:
-      - '@Drupal\os2loop_settings\Settings'
+      - '@os2loop_settings.settings'

--- a/web/profiles/custom/os2loop/modules/os2loop_search_db/os2loop_search_db.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_search_db/os2loop_search_db.module
@@ -8,7 +8,6 @@
 use Drupal\block\Entity\Block;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\os2loop_search_db\Helper\Helper;
 use Drupal\search_api\Query\QueryInterface;
 
 /**
@@ -33,14 +32,14 @@ function os2loop_search_db_help($route_name, RouteMatchInterface $route_match) {
  * @see \Drupal\os2loop_search_db\Helper\Helper::alterSuggestions()
  */
 function os2loop_search_db_search_api_autocomplete_suggestions_alter(array &$suggestions, array $alter_params) {
-  Drupal::service(Helper::class)->alterSuggestions($suggestions, $alter_params);
+  Drupal::service('os2loop_search_db.helper')->alterSuggestions($suggestions, $alter_params);
 }
 
 /**
  * Implements hook_search_api_query_alter().
  */
 function os2loop_search_db_search_api_query_alter(QueryInterface $query) {
-  Drupal::service(Helper::class)->alterSearchApiQuery($query);
+  Drupal::service('os2loop_search_db.helper')->alterSearchApiQuery($query);
 }
 
 /**
@@ -49,5 +48,5 @@ function os2loop_search_db_search_api_query_alter(QueryInterface $query) {
  * @see Helper::blockAccess()
  */
 function os2loop_search_db_block_access(Block $block, $operation, AccountInterface $account) {
-  return Drupal::service(Helper::class)->blockAccess($block, $operation, $account);
+  return Drupal::service('os2loop_search_db.helper')->blockAccess($block, $operation, $account);
 }

--- a/web/profiles/custom/os2loop/modules/os2loop_search_db/os2loop_search_db.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_search_db/os2loop_search_db.services.yml
@@ -1,5 +1,5 @@
 services:
-  Drupal\os2loop_search_db\Helper\Helper:
+  os2loop_search_db.helper:
     class: Drupal\os2loop_search_db\Helper\Helper
     arguments:
-      - '@Drupal\os2loop_settings\Settings'
+      - '@os2loop_settings.settings'

--- a/web/profiles/custom/os2loop/modules/os2loop_search_db/src/Plugin/facets/widget/DocumentWidget.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_search_db/src/Plugin/facets/widget/DocumentWidget.php
@@ -42,7 +42,7 @@ class DocumentWidget extends CheckboxWidget implements ContainerFactoryPluginInt
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get(Helper::class)
+      $container->get('os2loop_documents.helper')
     );
   }
 

--- a/web/profiles/custom/os2loop/modules/os2loop_settings/os2loop_settings.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_settings/os2loop_settings.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
-use Drupal\os2loop_settings\Helper\Helper;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -16,7 +15,7 @@ use Drupal\Core\Form\FormStateInterface;
  * @see Helper::entityCreateAccess()
  */
 function os2loop_settings_entity_create_access(AccountInterface $account, array $context, $entity_bundle) {
-  return Drupal::service(Helper::class)->entityCreateAccess($account, $context, $entity_bundle);
+  return Drupal::service('os2loop_settings.helper')->entityCreateAccess($account, $context, $entity_bundle);
 }
 
 /**
@@ -25,7 +24,7 @@ function os2loop_settings_entity_create_access(AccountInterface $account, array 
  * @see Helper::nodeAccess()
  */
 function os2loop_settings_node_access(NodeInterface $node, $op, AccountInterface $account) {
-  return Drupal::service(Helper::class)->nodeAccess($node, $op, $account);
+  return Drupal::service('os2loop_settings.helper')->nodeAccess($node, $op, $account);
 }
 
 /**
@@ -34,7 +33,7 @@ function os2loop_settings_node_access(NodeInterface $node, $op, AccountInterface
  * @see Helper::formAlter()
  */
 function os2loop_settings_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  return Drupal::service(Helper::class)->formAlter($form, $form_state, $form_id);
+  return Drupal::service('os2loop_settings.helper')->formAlter($form, $form_state, $form_id);
 }
 
 /**
@@ -43,5 +42,5 @@ function os2loop_settings_form_alter(&$form, FormStateInterface $form_state, $fo
  * @see Helper::preprocessNode()
  */
 function os2loop_settings_preprocess_node(array &$variables) {
-  return Drupal::service(Helper::class)->preprocessNode($variables);
+  return Drupal::service('os2loop_settings.helper')->preprocessNode($variables);
 }

--- a/web/profiles/custom/os2loop/modules/os2loop_settings/os2loop_settings.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_settings/os2loop_settings.services.yml
@@ -1,17 +1,17 @@
 services:
-  Drupal\os2loop_settings\Settings:
+  os2loop_settings.settings:
     class: Drupal\os2loop_settings\Settings
     arguments:
       - '@config.factory'
       - '@entity_type.manager'
 
-  Drupal\os2loop_settings\Helper\Helper:
+  os2loop_settings.helper:
     class: Drupal\os2loop_settings\Helper\Helper
     arguments:
-      - '@Drupal\os2loop_settings\Settings'
+      - '@os2loop_settings.settings'
       - '@messenger'
 
-  Drupal\os2loop_settings\TwigExtension\TwigExtension:
+  os2loop_settings.twig_extension:
     class: Drupal\os2loop_settings\TwigExtension\TwigExtension
     arguments:
       - '@current_user'

--- a/web/profiles/custom/os2loop/modules/os2loop_settings/src/Form/SettingsForm.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_settings/src/Form/SettingsForm.php
@@ -43,7 +43,7 @@ class SettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get(Settings::class)
+      $container->get('os2loop_settings.settings')
     );
   }
 

--- a/web/profiles/custom/os2loop/modules/os2loop_share_with_a_friend/os2loop_share_with_a_friend.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_share_with_a_friend/os2loop_share_with_a_friend.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\os2loop_share_with_a_friend\Helper\MailHelper
     arguments:
       - '@token'
-      - '@Drupal\os2loop_settings\Settings'
+      - '@os2loop_settings.settings'


### PR DESCRIPTION
Drupal cannot always handle using FQNs as service ids, so we change them to “normal” strings.
