### PR TITLE
LOOP-925: Embedded site logo

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/block/block--system-branding-block.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/block/block--system-branding-block.html.twig
@@ -17,11 +17,10 @@
 {% if site_logo %}
   <a href="{{ path('<front>') }}" rel="home" class="navbar-brand">
     <span class="visually-hidden">{{ 'Home'|t }}</span>
-    {% include(site_logo) %}
+    <img src="{{ site_logo }}"/>
   </a>
 {% endif %}
 {% if site_name %}
   <a href="{{ path('<front>') }}" rel="home">{{ site_name }}</a>
 {% endif %}
 {{ site_slogan }}
-


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-925

Including the logo fails when it's not an svg. This changes to embed (via `<img/>`) logo rather than include.