### PR TITLE
LOOP-935: Fixed check for route name on menu link with external url

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu--main.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu--main.html.twig
@@ -46,7 +46,7 @@
               item.in_active_trail ? 'active',
             ] %}
             <li{{ item.attributes.addClass(classes_list_item) }}>
-              {% if item.url.routeName == '<nolink>' %}
+              {% if not item.url.external and item.url.routeName == '<nolink>' %}
                 <a class="{{ classes_link|join(' ') }}" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   {{ item.title }}
                 </a>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-935

Fixes issue with handling of external urls in menu links.

```
UnexpectedValueException: External URLs do not have an internal route name. in Drupal\Core\Url->getRouteName() (line 564 of core/lib/Drupal/Core/Url.php).
twig_get_attribute() (Line: 107)
__TwigTemplate_ee23866e074fe3d26a259494ab6f4eff6b3219a5448742477e5b7384cb6254e7->macro_menu_links() (Line: 1110)
…
```