### PR TITLE
LOOP-874: Allowed administrator to manage theme

### DIFF
--- a/config/sync/user.role.os2loop_user_administrator.yml
+++ b/config/sync/user.role.os2loop_user_administrator.yml
@@ -62,6 +62,7 @@ permissions:
   - 'administer pcp'
   - 'administer redirects'
   - 'administer rules'
+  - 'administer themes'
   - 'administer url aliases'
   - 'administer users'
   - 'administer uuid'


### PR DESCRIPTION
# Link to issue

https://jira.itkdev.dk/browse/LOOP-874

# Description

Allows `administrator` to manage themes.

# Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
