### PR TITLE
LOOP-874: Added member list settings to config ignore

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -2,6 +2,7 @@ ignored_config_entities:
   - os2loop.settings
   - os2loop_flag_content.settings
   - os2loop_mail_notifications.settings
+  - os2loop_member_list.settings
   - os2loop_question.settings
   - os2loop_settings.settings
   - os2loop_share_with_a_friend.settings


### PR DESCRIPTION
# Link to issue

https://jira.itkdev.dk/browse/LOOP-874

# Description

Ignores OS2Loop Member list config when importing config.

# Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
