### PR TITLE
Position fix for user menu dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- [LOOP-948](https://jira.itkdev.dk/browse/LOOP-948): Fix position of user dropdown menu, that extends outside the viewport on narrow screens.
 - [LOOP-732](https://jira.itkdev.dk/browse/LOOP-732),
   [LOOP-733](https://jira.itkdev.dk/browse/LOOP-733) and
   [LOOP-734](https://jira.itkdev.dk/browse/LOOP-734): Drupal, SAML and OpenID

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/navbar.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/navbar.scss
@@ -16,9 +16,28 @@
   display: block;
 }
 
+// Fix for drop down menu, extending out of viewport when placed on at the right side of the page.
 .dropdown-menu {
   &.position-right {
     left: auto !important;
     right: 0;
+  }
+}
+
+// Toggle icon on mobile menu
+.navbar-toggler {
+  .bi-list {
+    display: none;
+  }
+  .bi-x {
+    display: inline;
+  }
+  &.collapsed {
+    .bi-list {
+      display: inline;
+    }
+    .bi-x {
+      display: none;
+    }
   }
 }

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/navbar.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/navbar.scss
@@ -15,3 +15,10 @@
 .dropdown-divider {
   display: block;
 }
+
+.dropdown-menu {
+  &.position-right {
+    left: auto !important;
+    right: 0;
+  }
+}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu--main.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu--main.html.twig
@@ -54,7 +54,7 @@
               {{ link(item.title, item.url, {'class': classes_link}) }}
               {% endif %}
               {% if item.below %}
-                <div class="dropdown-menu" aria-label="{{ item.title }}">
+                <div class="dropdown-menu position-right" aria-label="{{ item.title }}">
                   {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
                 </div>
               {% endif %}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu--main.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/navigation/menu--main.html.twig
@@ -24,8 +24,9 @@
   We call a macro which calls itself to render the full tree.
   @see http://twig.sensiolabs.org/doc/tags/macro.html
 #}
-<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarMain" aria-controls="navbarMain" aria-expanded="false" aria-label="Toggle navigation">
-  <span class="navbar-toggler-icon"></span>
+<button class="navbar-toggler text-white border collapsed" type="button" data-toggle="collapse" data-target="#navbarMain" aria-controls="navbarMain" aria-expanded="false" aria-label="Toggle navigation">
+  <i class="bi bi-list"></i>
+  <i class="bi bi-x"></i>
 </button>
 <div class="collapse navbar-collapse main-menu" id="navbarMain">
   {{ menus.menu_links(items, attributes, 0) }}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-948﻿

New position:
![Screenshot 2021-06-14 at 09 24 02](https://user-images.githubusercontent.com/332915/121854346-554a0b80-ccf2-11eb-85d9-8cafac68d4e7.png)

Mobile menu:
![Screenshot 2021-06-14 at 09 24 52](https://user-images.githubusercontent.com/332915/121854435-70b51680-ccf2-11eb-94bf-33aa76a68d1b.png)
![Screenshot 2021-06-14 at 09 25 07](https://user-images.githubusercontent.com/332915/121854433-6f83e980-ccf2-11eb-85f5-eec0bec49f72.png)