### PR TITLE
LOOP-1034: Updated table styling

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/documents.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/documents.scss
@@ -12,6 +12,16 @@
 table.loop-documents-table {
   @extend .table, .table-hover, .table-bordered;
 
+  th {
+    background: #ccc;
+    text-align: center;
+  }
+
+  th,
+  td {
+    vertical-align: top;
+  }
+
   p {
     margin-top: 0;
   }
@@ -22,6 +32,7 @@ table.loop-documents-table {
       text-align: center;
     }
   }
+
   img {
     height: auto !important;
     max-width: inherit !important;


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1034

Changes

<img width="1144" alt="Screen Shot 2021-08-05 at 21 37 38" src="https://user-images.githubusercontent.com/11267554/128411572-1c08b0c9-55c8-42b7-9383-77aa097c4cb2.png">

into

<img width="1144" alt="Screen Shot 2021-08-05 at 21 37 19" src="https://user-images.githubusercontent.com/11267554/128411579-5f3b3ae6-ad46-4959-becf-a1cabefe810a.png">

