### PR TITLE
LOOP-906: Fixed facet visibility

### DIFF
--- a/config/sync/facets.facet.os2loop_search_db_category.yml
+++ b/config/sync/facets.facet.os2loop_search_db_category.yml
@@ -33,7 +33,7 @@ expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0
 exclude: false
-only_visible_when_facet_source_is_visible: false
+only_visible_when_facet_source_is_visible: true
 processor_configs:
   display_value_widget_order:
     processor_id: display_value_widget_order


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-906

Fixes facet visiblity to show it only when searching.
