### PR TITLE
Anonymous authors

### DIFF
--- a/config/sync/core.entity_form_display.comment.os2loop_post_comment.default.yml
+++ b/config/sync/core.entity_form_display.comment.os2loop_post_comment.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - comment.type.os2loop_post_comment
+    - field.field.comment.os2loop_post_comment.os2loop_comment_anonymous_author
     - field.field.comment.os2loop_post_comment.os2loop_post_comment
   module:
     - text
@@ -17,8 +18,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  os2loop_post_comment:
+  os2loop_comment_anonymous_author:
+    type: options_select
     weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  os2loop_post_comment:
+    weight: 2
     settings:
       rows: 5
       placeholder: ''

--- a/config/sync/core.entity_form_display.comment.os2loop_question_answer.default.yml
+++ b/config/sync/core.entity_form_display.comment.os2loop_question_answer.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - comment.type.os2loop_question_answer
     - core.entity_form_mode.media.inline_media_form
+    - field.field.comment.os2loop_question_answer.os2loop_comment_anonymous_author
     - field.field.comment.os2loop_question_answer.os2loop_question_answer
     - field.field.comment.os2loop_question_answer.os2loop_question_answer_media
   module:
@@ -20,8 +21,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  os2loop_question_answer:
+  os2loop_comment_anonymous_author:
+    type: options_select
     weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  os2loop_question_answer:
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -30,7 +37,7 @@ content:
     region: content
   os2loop_question_answer_media:
     type: inline_entity_form_simple
-    weight: 2
+    weight: 3
     settings:
       form_mode: inline_media_form
       label_singular: ''

--- a/config/sync/core.entity_form_display.node.os2loop_documents_document.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_documents_document.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -31,6 +32,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  os2loop_content_anonymous_author:
+    weight: 26
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   os2loop_documents_document_autho:
     weight: 7
     settings:

--- a/config/sync/core.entity_form_display.node.os2loop_question.default.yml
+++ b/config/sync/core.entity_form_display.node.os2loop_question.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.media.inline_media_form
+    - field.field.node.os2loop_question.os2loop_content_anonymous_author
     - field.field.node.os2loop_question.os2loop_question_answers
     - field.field.node.os2loop_question.os2loop_question_content
     - field.field.node.os2loop_question.os2loop_question_file
@@ -29,14 +30,20 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  os2loop_content_anonymous_author:
+    weight: 4
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   os2loop_question_answers:
-    weight: 9
+    weight: 10
     settings: {  }
     third_party_settings: {  }
     type: comment_default
     region: content
   os2loop_question_content:
-    weight: 4
+    weight: 5
     settings:
       rows: 5
       placeholder: ''
@@ -45,7 +52,7 @@ content:
     region: content
   os2loop_question_file:
     type: inline_entity_form_simple
-    weight: 10
+    weight: 11
     settings:
       form_mode: inline_media_form
       label_singular: ''
@@ -57,7 +64,7 @@ content:
     third_party_settings: {  }
     region: content
   os2loop_shared_category:
-    weight: 5
+    weight: 6
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -82,7 +89,7 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-    weight: 8
+    weight: 9
   os2loop_shared_subject:
     settings:
       match_limit: '0'
@@ -99,7 +106,7 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-    weight: 6
+    weight: 7
   os2loop_shared_tags:
     settings:
       min_length: 0
@@ -116,10 +123,10 @@ content:
     third_party_settings: {  }
     type: autocomplete_deluxe
     region: content
-    weight: 7
+    weight: 8
   path:
     type: path
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.comment.os2loop_post_comment.default.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_post_comment.default.yml
@@ -35,4 +35,5 @@ hidden:
   entity_print_view_word_docx: true
   flag_os2loop_upvote_correct_answer: true
   langcode: true
+  os2loop_comment_anonymous_author: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.comment.os2loop_post_comment.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_post_comment.os2loop_search_db_search_autocomplete.yml
@@ -24,4 +24,5 @@ hidden:
   flag_os2loop_upvote_upvote_button: true
   langcode: true
   links: true
+  os2loop_comment_anonymous_author: true
   os2loop_post_comment: true

--- a/config/sync/core.entity_view_display.comment.os2loop_post_comment.search_result.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_post_comment.search_result.yml
@@ -24,4 +24,5 @@ hidden:
   flag_os2loop_upvote_upvote_button: true
   langcode: true
   links: true
+  os2loop_comment_anonymous_author: true
   os2loop_post_comment: true

--- a/config/sync/core.entity_view_display.comment.os2loop_question_answer.default.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_question_answer.default.yml
@@ -47,4 +47,5 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   langcode: true
+  os2loop_comment_anonymous_author: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.comment.os2loop_question_answer.list_display.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_question_answer.list_display.yml
@@ -41,5 +41,6 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   langcode: true
+  os2loop_comment_anonymous_author: true
   os2loop_question_answer_media: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.comment.os2loop_question_answer.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_question_answer.os2loop_search_db_search_autocomplete.yml
@@ -25,5 +25,6 @@ hidden:
   flag_os2loop_upvote_upvote_button: true
   langcode: true
   links: true
+  os2loop_comment_anonymous_author: true
   os2loop_question_answer: true
   os2loop_question_answer_media: true

--- a/config/sync/core.entity_view_display.comment.os2loop_question_answer.search_result.yml
+++ b/config/sync/core.entity_view_display.comment.os2loop_question_answer.search_result.yml
@@ -25,5 +25,6 @@ hidden:
   flag_os2loop_upvote_upvote_button: true
   langcode: true
   links: true
+  os2loop_comment_anonymous_author: true
   os2loop_question_answer: true
   os2loop_question_answer_media: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -17,6 +18,7 @@ dependencies:
   module:
     - datetime
     - entity_reference_revisions
+    - options
     - text
     - user
 id: node.os2loop_documents_document.default
@@ -39,6 +41,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  os2loop_content_anonymous_author:
+    weight: 12
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
   os2loop_documents_document_autho:
     weight: 4
     label: inline

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.list_display.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.list_display.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.list_display
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -92,6 +93,7 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   langcode: true
+  os2loop_content_anonymous_author: true
   os2loop_documents_document_body: true
   os2loop_documents_info_box: true
   os2loop_notify_users: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.os2loop_search_db_search_autocomplete.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.os2loop_search_db_search_autocomplete
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -51,6 +52,7 @@ hidden:
   entity_print_view_word_docx: true
   langcode: true
   links: true
+  os2loop_content_anonymous_author: true
   os2loop_documents_document_autho: true
   os2loop_documents_document_body: true
   os2loop_documents_document_conte: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.pdf.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.pdf.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.pdf
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -99,6 +100,7 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   langcode: true
+  os2loop_content_anonymous_author: true
   os2loop_notify_users: true
   os2loop_shared_category: true
   os2loop_shared_rev_date: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.search_result.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -51,6 +52,7 @@ hidden:
   entity_print_view_word_docx: true
   langcode: true
   links: true
+  os2loop_content_anonymous_author: true
   os2loop_documents_document_autho: true
   os2loop_documents_document_body: true
   os2loop_documents_document_conte: true

--- a/config/sync/core.entity_view_display.node.os2loop_documents_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_documents_document.teaser.yml
@@ -4,6 +4,7 @@ status: false
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.os2loop_documents_document.os2loop_content_anonymous_author
     - field.field.node.os2loop_documents_document.os2loop_documents_document_autho
     - field.field.node.os2loop_documents_document.os2loop_documents_document_body
     - field.field.node.os2loop_documents_document.os2loop_documents_document_conte
@@ -44,6 +45,7 @@ hidden:
   flag_os2loop_favourite: true
   langcode: true
   links: true
+  os2loop_content_anonymous_author: true
   os2loop_documents_document_autho: true
   os2loop_documents_document_body: true
   os2loop_documents_document_conte: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.default.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_display.comment.os2loop_question_answer.default
+    - field.field.node.os2loop_question.os2loop_content_anonymous_author
     - field.field.node.os2loop_question.os2loop_question_answers
     - field.field.node.os2loop_question.os2loop_question_content
     - field.field.node.os2loop_question.os2loop_question_file
@@ -14,6 +15,7 @@ dependencies:
     - node.type.os2loop_question
   module:
     - comment
+    - options
     - text
     - user
 id: node.os2loop_question.default
@@ -36,6 +38,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  os2loop_content_anonymous_author:
+    weight: 10
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
   os2loop_question_answers:
     weight: 6
     label: above

--- a/config/sync/core.entity_view_display.node.os2loop_question.list_display.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.list_display.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_display.comment.os2loop_question_answer.default
     - core.entity_view_mode.node.list_display
+    - field.field.node.os2loop_question.os2loop_content_anonymous_author
     - field.field.node.os2loop_question.os2loop_question_answers
     - field.field.node.os2loop_question.os2loop_question_content
     - field.field.node.os2loop_question.os2loop_question_file
@@ -90,5 +91,6 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   langcode: true
+  os2loop_content_anonymous_author: true
   os2loop_question_file: true
   search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.os2loop_search_db_search_autocomplete.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.os2loop_search_db_search_autocomplete.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.os2loop_search_db_search_autocomplete
+    - field.field.node.os2loop_question.os2loop_content_anonymous_author
     - field.field.node.os2loop_question.os2loop_question_answers
     - field.field.node.os2loop_question.os2loop_question_content
     - field.field.node.os2loop_question.os2loop_question_file
@@ -47,6 +48,7 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   langcode: true
+  os2loop_content_anonymous_author: true
   os2loop_question_answers: true
   os2loop_question_content: true
   os2loop_question_file: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.search_result.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.search_result.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.search_result
+    - field.field.node.os2loop_question.os2loop_content_anonymous_author
     - field.field.node.os2loop_question.os2loop_question_answers
     - field.field.node.os2loop_question.os2loop_question_content
     - field.field.node.os2loop_question.os2loop_question_file
@@ -48,6 +49,7 @@ hidden:
   entity_print_view_word_docx: true
   langcode: true
   links: true
+  os2loop_content_anonymous_author: true
   os2loop_question_answers: true
   os2loop_question_content: true
   os2loop_question_file: true

--- a/config/sync/core.entity_view_display.node.os2loop_question.teaser.yml
+++ b/config/sync/core.entity_view_display.node.os2loop_question.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_display.comment.os2loop_question_answer.default
     - core.entity_view_mode.node.teaser
+    - field.field.node.os2loop_question.os2loop_content_anonymous_author
     - field.field.node.os2loop_question.os2loop_question_answers
     - field.field.node.os2loop_question.os2loop_question_content
     - field.field.node.os2loop_question.os2loop_question_file
@@ -59,6 +60,7 @@ hidden:
   flag_os2loop_favourite: true
   langcode: true
   links: true
+  os2loop_content_anonymous_author: true
   os2loop_question_answers: true
   os2loop_question_content: true
   os2loop_question_file: true

--- a/config/sync/field.field.comment.os2loop_post_comment.os2loop_comment_anonymous_author.yml
+++ b/config/sync/field.field.comment.os2loop_post_comment.os2loop_comment_anonymous_author.yml
@@ -1,0 +1,21 @@
+uuid: ac2e3c11-4f4b-4fb4-ab27-2ea871f81ec6
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.os2loop_post_comment
+    - field.storage.comment.os2loop_comment_anonymous_author
+  module:
+    - options
+id: comment.os2loop_post_comment.os2loop_comment_anonymous_author
+field_name: os2loop_comment_anonymous_author
+entity_type: comment
+bundle: os2loop_post_comment
+label: 'Anonymous author?'
+description: 'Choose if you want to show your name when people view your comment.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.comment.os2loop_question_answer.os2loop_comment_anonymous_author.yml
+++ b/config/sync/field.field.comment.os2loop_question_answer.os2loop_comment_anonymous_author.yml
@@ -1,0 +1,21 @@
+uuid: a6a78056-1352-4a30-ae52-50c9cb97477d
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.os2loop_question_answer
+    - field.storage.comment.os2loop_comment_anonymous_author
+  module:
+    - options
+id: comment.os2loop_question_answer.os2loop_comment_anonymous_author
+field_name: os2loop_comment_anonymous_author
+entity_type: comment
+bundle: os2loop_question_answer
+label: 'Anonymous author?'
+description: 'Choose if you want to show your name when people view your answer.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.os2loop_documents_document.os2loop_content_anonymous_author.yml
+++ b/config/sync/field.field.node.os2loop_documents_document.os2loop_content_anonymous_author.yml
@@ -1,0 +1,21 @@
+uuid: 623298b0-b959-4657-a32e-b5ad1d083777
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.os2loop_content_anonymous_author
+    - node.type.os2loop_documents_document
+  module:
+    - options
+id: node.os2loop_documents_document.os2loop_content_anonymous_author
+field_name: os2loop_content_anonymous_author
+entity_type: node
+bundle: os2loop_documents_document
+label: 'Anonymous author?'
+description: 'Choose whether you want to show your name or not when people see the document.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.os2loop_question.os2loop_content_anonymous_author.yml
+++ b/config/sync/field.field.node.os2loop_question.os2loop_content_anonymous_author.yml
@@ -1,0 +1,21 @@
+uuid: eafb1645-94e9-4883-8151-cf89c486123e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.os2loop_content_anonymous_author
+    - node.type.os2loop_question
+  module:
+    - options
+id: node.os2loop_question.os2loop_content_anonymous_author
+field_name: os2loop_content_anonymous_author
+entity_type: node
+bundle: os2loop_question
+label: 'Anonymous author?'
+description: 'Choose if you want to show your name when people view your question.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.comment.os2loop_comment_anonymous_author.yml
+++ b/config/sync/field.storage.comment.os2loop_comment_anonymous_author.yml
@@ -1,0 +1,27 @@
+uuid: c026eea2-d5d2-47c9-b6c1-ea344b2cd99d
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - options
+id: comment.os2loop_comment_anonymous_author
+field_name: os2loop_comment_anonymous_author
+entity_type: comment
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '1'
+      label: 'Yes'
+    -
+      value: '0'
+      label: 'No'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.os2loop_content_anonymous_author.yml
+++ b/config/sync/field.storage.node.os2loop_content_anonymous_author.yml
@@ -1,0 +1,27 @@
+uuid: bce2732a-91eb-4df4-9175-9c89568106e1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.os2loop_content_anonymous_author
+field_name: os2loop_content_anonymous_author
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '1'
+      label: 'Yes'
+    -
+      value: '0'
+      label: 'No'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language/da/field.field.comment.os2loop_post_comment.os2loop_comment_anonymous_author.yml
+++ b/config/sync/language/da/field.field.comment.os2loop_post_comment.os2loop_comment_anonymous_author.yml
@@ -1,0 +1,1 @@
+description: 'Vælg om dit navn må vises når brugere ser din kommentar.'

--- a/config/sync/language/da/field.field.comment.os2loop_question_answer.os2loop_comment_anonymous_author.yml
+++ b/config/sync/language/da/field.field.comment.os2loop_question_answer.os2loop_comment_anonymous_author.yml
@@ -1,0 +1,1 @@
+description: 'Vælg om dit navn må vises når brugere ser dit svar.'

--- a/config/sync/language/da/field.field.node.os2loop_question.os2loop_content_anonymous_author.yml
+++ b/config/sync/language/da/field.field.node.os2loop_question.os2loop_content_anonymous_author.yml
@@ -1,0 +1,2 @@
+label: 'Anonym forfatter?'
+description: 'Vælg om dit navn må vises når brugere ser dit spørgsmål.'

--- a/config/sync/language/da/field.storage.comment.os2loop_comment_anonymous_author.yml
+++ b/config/sync/language/da/field.storage.comment.os2loop_comment_anonymous_author.yml
@@ -1,0 +1,6 @@
+settings:
+  allowed_values:
+    -
+      label: Ja
+    -
+      label: Nej

--- a/config/sync/language/da/field.storage.node.os2loop_content_anonymous_author.yml
+++ b/config/sync/language/da/field.storage.node.os2loop_content_anonymous_author.yml
@@ -1,0 +1,6 @@
+settings:
+  allowed_values:
+    -
+      label: Ja
+    -
+      label: Nej

--- a/config/sync/os2loop_post.settings.yml
+++ b/config/sync/os2loop_post.settings.yml
@@ -1,0 +1,1 @@
+allow_anonymous_comment_author: 0

--- a/config/sync/os2loop_question.settings.yml
+++ b/config/sync/os2loop_question.settings.yml
@@ -1,1 +1,3 @@
 enable_rich_text: 0
+allow_anonymous_question_author: 0
+allow_anonymous_answer_author: 0

--- a/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.info.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.info.yml
@@ -7,5 +7,6 @@ dependencies:
   - drupal:better_formats
   - drupal:comment
   - drupal:image
+  - drupal:os2loop_settings
   - drupal:os2loop_shared
   - drupal:os2loop_taxonomy

--- a/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.links.menu.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.links.menu.yml
@@ -1,0 +1,6 @@
+os2loop_post.settings:
+  title: 'OS2Loop post settings'
+  route_name: os2loop_post.settings
+  description: 'Configure OS2Loop post settings'
+  parent: os2loop.group.admin
+  weight: 10

--- a/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.module
@@ -33,3 +33,12 @@ function os2loop_post_help($route_name, RouteMatchInterface $route_match) {
 function os2loop_post_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   Drupal::service(Helper::class)->alterForm($form, $form_state, $form_id);
 }
+
+/**
+ * Implements hook_os2loop_settings_is_granted().
+ *
+ * @see \Drupal\os2loop_post\Helper\Helper::isGranted()
+ */
+function os2loop_post_os2loop_settings_is_granted(string $attribute, $object = NULL) {
+  return Drupal::service(Helper::class)->isGranted($attribute, $object);
+}

--- a/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.module
@@ -33,12 +33,3 @@ function os2loop_post_help($route_name, RouteMatchInterface $route_match) {
 function os2loop_post_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   Drupal::service(Helper::class)->alterForm($form, $form_state, $form_id);
 }
-
-/**
- * Implements hook_os2loop_settings_is_granted().
- *
- * @see \Drupal\os2loop_post\Helper\Helper::isGranted()
- */
-function os2loop_post_os2loop_settings_is_granted(string $attribute, $object = NULL) {
-  return Drupal::service(Helper::class)->isGranted($attribute, $object);
-}

--- a/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.routing.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.routing.yml
@@ -1,0 +1,7 @@
+os2loop_post.settings:
+  path: '/admin/config/os2loop/os2loop_post/settings'
+  defaults:
+    _form: '\Drupal\os2loop_post\Form\SettingsForm'
+    _title: 'OS2Loop post settings'
+  requirements:
+    _permission: 'administer os2loop settings'

--- a/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.services.yml
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/os2loop_post.services.yml
@@ -1,3 +1,5 @@
 services:
   Drupal\os2loop_post\Helper\Helper:
     class: Drupal\os2loop_post\Helper\Helper
+    arguments:
+      - '@Drupal\os2loop_settings\Settings'

--- a/web/profiles/custom/os2loop/modules/os2loop_post/src/Form/SettingsForm.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/src/Form/SettingsForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\os2loop_question\Form;
+namespace Drupal\os2loop_post\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
@@ -10,7 +10,7 @@ use Drupal\os2loop_settings\Settings;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Configure question settings for this site.
+ * Configure post settings for this site.
  */
 class SettingsForm extends ConfigFormBase {
   use StringTranslationTrait;
@@ -20,7 +20,7 @@ class SettingsForm extends ConfigFormBase {
    *
    * @var string
    */
-  public const SETTINGS_NAME = 'os2loop_question.settings';
+  public const SETTINGS_NAME = 'os2loop_post.settings';
 
   /**
    * The settings.
@@ -69,25 +69,11 @@ class SettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->settings->getConfig(static::SETTINGS_NAME);
 
-    $form['enable_rich_text'] = [
+    $form['allow_anonymous_comment_author'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Enable rich text in questions'),
-      '#description' => $this->t('<strong>Note</strong>: This has effect for new questions only. Existing questions will keep their current text format.'),
-      '#default_value' => $config->get('enable_rich_text'),
-    ];
-
-    $form['allow_anonymous_question_author'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Allow anonymous question author'),
-      '#description' => $this->t('If set, question authors can choose to hide their name when a question is viewed.'),
-      '#default_value' => $config->get('allow_anonymous_question_author'),
-    ];
-
-    $form['allow_anonymous_answer_author'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Allow anonymous answer author'),
-      '#description' => $this->t('If set, answer authors can choose to hide their name when an answer is viewed.'),
-      '#default_value' => $config->get('allow_anonymous_answer_author'),
+      '#title' => $this->t('Allow anonymous comment author'),
+      '#description' => $this->t('If set, comment authors can choose to hide their name when a comment is viewed.'),
+      '#default_value' => $config->get('allow_anonymous_comment_author'),
     ];
 
     return parent::buildForm($form, $form_state);
@@ -98,9 +84,7 @@ class SettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->configFactory->getEditable(static::SETTINGS_NAME)
-      ->set('enable_rich_text', $form_state->getValue('enable_rich_text'))
-      ->set('allow_anonymous_question_author', $form_state->getValue('allow_anonymous_question_author'))
-      ->set('allow_anonymous_answer_author', $form_state->getValue('allow_anonymous_answer_author'))
+      ->set('allow_anonymous_comment_author', $form_state->getValue('allow_anonymous_comment_author'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/web/profiles/custom/os2loop/modules/os2loop_post/src/Helper/Helper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_post/src/Helper/Helper.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\os2loop_post\Helper;
 
-use Drupal\comment\CommentInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\os2loop_post\Form\SettingsForm;
 use Drupal\os2loop_settings\Settings;
@@ -80,21 +79,6 @@ class Helper {
     }
 
     return $form_element;
-  }
-
-  /**
-   * Implements hook_os2loop_settings_is_granted().
-   */
-  public function isGranted(string $attribute, $object = NULL): bool {
-    if ('view author' === $attribute) {
-      if ($object instanceof CommentInterface) {
-        if ($object->hasField('os2loop_comment_anonymous_author')) {
-          return FALSE === (bool) $object->get('os2loop_comment_anonymous_author')->getString();
-        }
-      }
-    }
-
-    return FALSE;
   }
 
 }

--- a/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.module
@@ -33,12 +33,3 @@ function os2loop_question_help($route_name, RouteMatchInterface $route_match) {
 function os2loop_question_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   Drupal::service(Helper::class)->alterForm($form, $form_state, $form_id);
 }
-
-/**
- * Implements hook_os2loop_settings_is_granted().
- *
- * @see \Drupal\os2loop_question\Helper\Helper::isGranted()
- */
-function os2loop_question_os2loop_settings_is_granted(string $attribute, $object = NULL) {
-  return Drupal::service(Helper::class)->isGranted($attribute, $object);
-}

--- a/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.module
+++ b/web/profiles/custom/os2loop/modules/os2loop_question/os2loop_question.module
@@ -33,3 +33,12 @@ function os2loop_question_help($route_name, RouteMatchInterface $route_match) {
 function os2loop_question_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   Drupal::service(Helper::class)->alterForm($form, $form_state, $form_id);
 }
+
+/**
+ * Implements hook_os2loop_settings_is_granted().
+ *
+ * @see \Drupal\os2loop_question\Helper\Helper::isGranted()
+ */
+function os2loop_question_os2loop_settings_is_granted(string $attribute, $object = NULL) {
+  return Drupal::service(Helper::class)->isGranted($attribute, $object);
+}

--- a/web/profiles/custom/os2loop/modules/os2loop_question/src/Helper/Helper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_question/src/Helper/Helper.php
@@ -2,9 +2,7 @@
 
 namespace Drupal\os2loop_question\Helper;
 
-use Drupal\comment\CommentInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\NodeInterface;
 use Drupal\os2loop_question\Form\SettingsForm;
 use Drupal\os2loop_settings\Settings;
 
@@ -137,26 +135,6 @@ class Helper {
     }
 
     return $form_element;
-  }
-
-  /**
-   * Implements hook_os2loop_settings_is_granted().
-   */
-  public function isGranted(string $attribute, $object = NULL): bool {
-    if ('view author' === $attribute) {
-      if ($object instanceof NodeInterface) {
-        if ($object->hasField('os2loop_content_anonymous_author')) {
-          return FALSE === (bool) $object->get('os2loop_content_anonymous_author')->getString();
-        }
-      }
-      elseif ($object instanceof CommentInterface) {
-        if ($object->hasField('os2loop_comment_anonymous_author')) {
-          return FALSE === (bool) $object->get('os2loop_comment_anonymous_author')->getString();
-        }
-      }
-    }
-
-    return FALSE;
   }
 
 }

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/comment--os2loop-post-comments.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/comment--os2loop-post-comments.html.twig
@@ -90,7 +90,7 @@
       </h1>
     {% endif %}
     {{ title_suffix }}
-    {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', comment.uid.target_id), date: created} %}
+    {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', comment.uid.target_id), date: created, entity: comment} %}
   </div>
   {#
     Indicate the semantic relationship between parent and child comments for

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/comment--os2loop-question-answers.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/comment--os2loop-question-answers.html.twig
@@ -90,7 +90,7 @@
       </h1>
     {% endif %}
     {{ title_suffix }}
-    {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', comment.uid.target_id), date: created} %}
+    {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', comment.uid.target_id), date: created, entity: comment} %}
   </div>
   {#
     Indicate the semantic relationship between parent and child comments for

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-post.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-post.html.twig
@@ -74,7 +74,7 @@
 
 <article{{ attributes.addClass("os2loop-content os2loop-post") }}>
   {{ macros.title(label, "post", node, content, false) }}
-  {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', node.uid.target_id)} %}
+  {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', node.uid.target_id), entity: node} %}
   <div{{ content_attributes.addClass('mt-3 mb-5 px-3') }}>
     {{ content.os2loop_post_content }}
     <div class="row mt-3 mt-md-5 py-2 bg-light">

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-question.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-question.html.twig
@@ -74,7 +74,7 @@
 
 <article{{ attributes.addClass("os2loop-content os2loop-question") }}>
   {{ macros.title(label, "question", node, content, false) }}
-  {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', node.uid.target_id)} %}
+  {% include '@os2loop_theme/field/user-info.html.twig' with {user: drupal_entity('user', node.uid.target_id), entity: node} %}
   <div{{ content_attributes.addClass('mt-3 mb-5 px-3') }}>
     {{ content.os2loop_question_content }}
     <div class="row mt-3 mt-md-5 py-2 bg-light">

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/user-info.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/user-info.html.twig
@@ -7,29 +7,48 @@
  * - user: The user to display info about.
  */
 #}
-<div class="user rounded-top">
-  <div class="col-auto">
-    {% set image = user['#user'].id is not empty ? drupal_field('os2loop_user_image', 'user', user['#user'].id, 'compact') %}
-    {% if image['#items'] is not empty %}
-      <div class="user-image">{{ image }}</div>
-    {% else %}
-      <i class="bi bi-person-circle"></i>
+{% set display_author = entity is empty or is_granted('view author', entity) %}
+{% if display_author %}
+
+  <div class="user rounded-top">
+    <div class="col-auto">
+      {% set image = user['#user'].id is not empty ? drupal_field('os2loop_user_image', 'user', user['#user'].id, 'compact') %}
+      {% if image['#items'] is not empty %}
+        <div class="user-image">{{ image }}</div>
+      {% else %}
+        <i class="bi bi-person-circle"></i>
+      {% endif %}
+    </div>
+    <div class="col">user</div>
+      {% if user['#user'].os2loop_user_job_title.value %}
+      <div class="col">
+        <div>
+          {% set user_url = user['#user'].id is not empty ? url('entity.user.canonical', {'user': user['#user'].id}) : '#' %}
+          <a href="{{ user_url }}">{{ user['#user'].os2loop_user_given_name.value }} {{ user['#user'].os2loop_user_family_name.value }}</a>
+        </div>
+        <div>
+          <span class="small">{{ user['#user'].os2loop_user_job_title.value }}, {{ user['#user'].os2loop_user_place.value }}</span>
+        </div>
+      </div>
+    {% endif %}
+    {% if date %}
+      <div class="col">
+        <span class="small">{{ 'Posted'|t }}: {{ date }}</span>
+      </div>
     {% endif %}
   </div>
-  {% if user['#user'].os2loop_user_job_title.value %}
-    <div class="col">
-      <div>
-        {% set user_url = user['#user'].id is not empty ? url('entity.user.canonical', {'user': user['#user'].id}) : '#' %}
-        <a href="{{ user_url }}">{{ user['#user'].os2loop_user_given_name.value }} {{ user['#user'].os2loop_user_family_name.value }}</a>
-      </div>
-      <div>
-        <span class="small">{{ user['#user'].os2loop_user_job_title.value }}, {{ user['#user'].os2loop_user_place.value }}</span>
-      </div>
+
+{% else %}
+
+  <div class="user rounded-top">
+    <div class="col-auto">
+      <i class="bi bi-person-circle"></i>
     </div>
-  {% endif %}
-  {% if date %}
-    <div class="col">
-      <span class="small">{{ 'Posted'|t }}: {{ date }}</span>
-    </div>
+    {% if date %}
+      <div class="col">
+        <span class="small">{{ 'Posted'|t }}: {{ date }}</span>
+      </div>
     {% endif %}
-</div>
+  </div>
+
+{% endif %}

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/user-info.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/user-info.html.twig
@@ -7,7 +7,8 @@
  * - user: The user to display info about.
  */
 #}
-{% set display_author = entity is empty or is_granted('view author', entity) %}
+{# Display author if not anonymous #}
+{% set display_author = not entity or not(entity.os2loop_content_anonymous_author.value or entity.os2loop_comment_anonymous_author.value) %}
 {% if display_author %}
 
   <div class="user rounded-top">


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1145

Adds “Anonymous author?” fields to questions, answers and comments (on posts).

If authors are allowed to be anonymous (cf. /admin/config/os2loop/os2loop_question/settings and admin/config/os2loop/os2loop_post/settings), the author has to decide if his name is shown when a piece of content is displayed.