### PR TITLE
LOOP-1171: Tweaked display of anonymous author

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/user-info.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/user-info.html.twig
@@ -9,8 +9,8 @@
 #}
 {# Display author if not anonymous #}
 {% set display_author = not entity or not(entity.os2loop_content_anonymous_author.value or entity.os2loop_comment_anonymous_author.value) %}
-{% if display_author %}
-  <div class="rounded-top d-flex">
+<div class="rounded-top d-flex">
+  {% if display_author %}
     <div class="col-auto">
       {% set image = user['#user'].id is not empty ? drupal_field('os2loop_user_image', 'user', user['#user'].id, 'compact') %}
       {% if image['#items'] is not empty %}
@@ -35,11 +35,9 @@
         <span class="small">{{ 'Posted'|t }}: {{ date }}</span>
       </div>
     {% endif %}
-  </div>
 
-{% else %}
+  {% else %}
 
-  <div class="user rounded-top">
     <div class="col-auto">
       <i class="bi bi-person-circle"></i>
     </div>
@@ -48,6 +46,6 @@
         <span class="small">{{ 'Posted'|t }}: {{ date }}</span>
       </div>
     {% endif %}
-  </div>
 
-{% endif %}
+  {% endif %}
+</div>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1171

Tweaks display of anonymous author.

Before
<img width="1428" alt="Screen Shot 2022-01-03 at 09 53 07" src="https://user-images.githubusercontent.com/11267554/147913374-791582c2-20bf-449a-aaef-3197c67ee59f.png">

After
<img width="1428" alt="Screen Shot 2022-01-03 at 09 53 14" src="https://user-images.githubusercontent.com/11267554/147913385-11a9494a-8902-45ad-a39a-24e5cbab7b31.png">

