### PR TITLE
LOOP-1197: Changed sort to ensure that the newly created image is alw…

### DIFF
--- a/config/sync/views.view.media_library.yml
+++ b/config/sync/views.view.media_library.yml
@@ -446,7 +446,23 @@ display:
           empty: true
           content: 'No media available.'
           tokenize: false
-      sorts: {  }
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
       filters:
         combine:
           id: combine


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1197

Problem: Newly created images are not automatically selected after creation.
Cause: The new image does not appear in the list since the list has a display limit of 24 images. This causes the javascript select feature to fail since it can't find the image.
Solution: Change list sort order to display newest images first.