### PR TITLE
LOOP-1220: Fixed display of collection list

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -101,6 +101,10 @@
     {% set tabs = tabs|merge([
       {'id': 'about-collection', 'name': 'Document collection'|t}
     ]) %}
+  {% elseif os2loop_documents_collections|default(false) %}
+    {% set tabs = tabs|merge([
+      {'id': 'about-collections', 'name': 'Document collections'|t}
+    ]) %}
   {% endif %}
   {% include '@os2loop_theme/navigation/content-tabs.html.twig' with {'tabs': tabs, 'id': 'document-tabs'} %}
   <div class="tab-content" id="document-tabs-content">
@@ -131,16 +135,17 @@
             <div class="h5">{{ 'Documents in collection'|t }}</div>
             {{ macros.table_of_contents(os2loop_documents_collection_tree, os2loop_documents_collection, node.id) }}
           </div>
-        {% elseif os2loop_documents_collections|default(false) %}
-          <div>
-            <h2>{{ 'Document is part of these collections'|t }}</h2>
-            <ol>
-              {% for collection in os2loop_documents_collections %}
-                <li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
-              {% endfor %}
-            </ol>
-          </div>
         {% endif %}
+      </div>
+    {% elseif os2loop_documents_collections|default(false) %}
+      <div class="tab-pane" id="about-collections" role="tabpanel" aria-labelledby="about-collections">
+        {# We use div here to prevent it from appearing in TOC #}
+        <div class="h5">{{ 'Document is part of these collections'|t }}</div>
+        <ol>
+          {% for collection in os2loop_documents_collections %}
+            <li><a href="{{ path('entity.node.canonical', {node: node.id, collection: collection.id, collection: collection.id}) }}">{{ collection.title.value }}</a></li>
+          {% endfor %}
+        </ol>
       </div>
     {% endif %}
   </div>

--- a/web/profiles/custom/os2loop/translations/translations.da.po
+++ b/web/profiles/custom/os2loop/translations/translations.da.po
@@ -29282,6 +29282,9 @@ msgstr "Dokumentsamling"
 msgid "Document collections"
 msgstr "Dokumentsamlinger"
 
+msgid "Document is part of these collections"
+msgstr "Dokumentet indgår i disse dokumentsamlinger"
+
 msgid "Document metadata"
 msgstr "Om dokumentet"
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1220

Fixes missing display of list of collections a document is part of (if no collection context is defined by the url):

<img width="571" alt="Screenshot 2022-08-09 at 13 11 24" src="https://user-images.githubusercontent.com/11267554/183633952-6ca2e445-cf20-4922-a8e1-366b94d10b85.png">

