### PR TITLE
LOOP-1227: Removed alert styling from info box

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/field--os2loop-documents-info-box.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/field--os2loop-documents-info-box.html.twig
@@ -32,6 +32,6 @@ highlight_color
 %}
 <div{{ attributes.addClass(classes) }}>
   {% for item in items %}
-    <div {{ item.attributes.addClass('alert alert-success') }}>{{ item.content }}</div>
+    <div {{ item.attributes }}>{{ item.content }}</div>
   {% endfor %}
 </div>


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1227

Before:

<img width="1477" alt="Screenshot 2022-08-24 at 14 16 21" src="https://user-images.githubusercontent.com/11267554/186416134-f5321653-6fd0-4edd-bdc2-c8a93ef91b1d.png">

After:

<img width="1477" alt="Screenshot 2022-08-24 at 14 16 41" src="https://user-images.githubusercontent.com/11267554/186416098-e05c377a-57ef-4109-a60a-51c8929c2822.png">

