### PR TITLE
LOOP-1237: Make external links open in new tab

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/app.js
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/app.js
@@ -38,4 +38,12 @@ jQuery(() => {
 				.parent()
 				.removeClass("search-api-autocomplete-has-suggestions")
 		);
+
+	// Add target="_blank" to all external links in main content.
+	jQuery(".os2loop-main-content a").each((index, el) => {
+		const $el = $(el);
+		if (/^https?:\/\//.test($el.attr("href")) && !$el.attr("target")) {
+			$el.attr("target", "_blank");
+		}
+	});
 });

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-collection.html.twig
@@ -85,7 +85,7 @@
   <div class="tab-content" id="document-tabs-content">
     <div class="tab-pane show active" id="collection" role="tabpanel" aria-labelledby="collection-tab">
       {{ macros.title(label, "collection", node, content) }}
-      <div{{ content_attributes }}>
+      <div{{ content_attributes.addClass('os2loop-main-content') }}>
         {{ content.os2loop_documents_info_box }}
         {{ content.os2loop_documents_dc_content }}
       </div>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content/node--os2loop-documents-document.html.twig
@@ -113,7 +113,7 @@
   <div class="tab-content" id="document-tabs-content">
     <div class="tab-pane show active" id="document" role="tabpanel" aria-labelledby="document-tab">
       {{ macros.title(label, "document", node, content) }}
-      <div{{ content_attributes }}>
+      <div{{ content_attributes.addClass('os2loop-main-content') }}>
         {{ content.os2loop_documents_info_box }}
         {{ content.os2loop_documents_document_body }}
         {{ content.os2loop_documents_document_conte }}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1237

Makes external links (starting with `http://` er `https://`) in main content in documents and document collections open in new tabs (`target="_blank"`).