### PR TITLE
LOOP-1245: Wrap badges instead of inline.

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/components/layout/title.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/components/layout/title.scss
@@ -11,11 +11,15 @@
 		color: $loop-white;
 	}
 
-	.title-badges {
-		div + div,
-		span + a.badge,
-		a.badge + a.badge {
-			@extend .ml-15;
-		}
+	&-badges {
+		display: flex;
+		column-gap: 15px;
+		align-items: flex-start;
+
+		// div + div,
+		// span + a.badge,
+		// a.badge + a.badge {
+		// 	@extend .ml-15;
+		// }
 	}
 }

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/components/layout/title.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/components/layout/title.scss
@@ -15,11 +15,5 @@
 		display: flex;
 		column-gap: 15px;
 		align-items: flex-start;
-
-		// div + div,
-		// span + a.badge,
-		// a.badge + a.badge {
-		// 	@extend .ml-15;
-		// }
 	}
 }

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/field--node--os2loop-shared-profession.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/field/field--node--os2loop-shared-profession.html.twig
@@ -39,7 +39,7 @@
 #}
 {% import '@os2loop_theme/macros.html.twig' as macros %}
 
-<div{{ attributes }} class="d-inline-flex align-items-center">
+<div{{ attributes }} class="align-items-center">
   <span{{ title_attributes.addClass(element['#view_mode'] == 'list_display' ? 'd-none') }}>
     {{ label }}:
   </span>

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/macros.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/macros.html.twig
@@ -37,7 +37,7 @@
         </div>
       </div>
       <div class="row no-gutters mb-30">
-        <div class="col title-badges d-inline-flex">
+        <div class="col title-badges">
           {# badges #}
           <div class="badge badge-{{ class }}">{{ class|capitalize|t }}</div>
           {{ content.os2loop_shared_subject }}


### PR DESCRIPTION
https://jira.itkdev.dk/browse/LOOP-1245

Change behaviour of bagdes to wrap inside container

After:
![Screenshot 2022-08-30 at 13 17 37](https://user-images.githubusercontent.com/332915/187423902-3853821e-d3a2-43e8-997d-0f12ef5aa878.png)
![Screenshot 2022-08-30 at 13 17 30](https://user-images.githubusercontent.com/332915/187423906-4f434c0f-b75a-4db1-9aef-30fe30554c5c.png)


Before: 
![Screenshot 2022-08-30 at 11 28 15](https://user-images.githubusercontent.com/332915/187401830-89906574-dd0e-4388-bf06-df74ae2e4ee8.png)
