### PR TITLE
SUPP0RT-644: Fixed step title display in pdf

### DIFF
--- a/web/profiles/custom/os2loop/themes/os2loop_theme/assets/components/pdf/pdf.scss
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/assets/components/pdf/pdf.scss
@@ -49,4 +49,15 @@ img {
 	display: initial !important;
 }
 
+// Quick 'n' dirty solution.
+.paragraph--type--os2loop-documents-step {
+	&::marker,
+	.step--collapse-toggle {
+		font: {
+			size: 1.25rem;
+			weight: bold;
+		}
+	}
+}
+
 @import "layout";

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/paragraph--os2loop-documents-step.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/paragraph--os2loop-documents-step.html.twig
@@ -54,11 +54,20 @@
 {% block paragraph %}
   {% block content %}
     <li {{ attributes.addClass(classes) }}>
-      <a class="collapsed step--collapse-toggle" type="button" data-toggle="collapse" data-target="#paragraph-id-{{ paragraph.id() }}">
-        <span class="bold {{ has_title ?: 'line-clamp-1' }}">
-          {{ has_title ? content.os2loop_documents_step_title : content.os2loop_documents_step_text }}
+      {# A hack to check if we're rendering content for pdf generation #}
+      {% if 'print/pdf' in url('<current>')['#markup'] %}
+        <span class="collapsed step--collapse-toggle">
+          <span class="bold">
+            {{ has_title ? content.os2loop_documents_step_title : content.os2loop_documents_step_text }}
+          </span>
         </span>
-      </a>
+      {% else %}
+        <a class="collapsed step--collapse-toggle" type="button" data-toggle="collapse" data-target="#paragraph-id-{{ paragraph.id() }}">
+          <span class="bold {{ has_title ? 'line-clamp-1' }}">
+            {{ has_title ? content.os2loop_documents_step_title : content.os2loop_documents_step_text }}
+          </span>
+        </a>
+      {% endif %}
       <div class="row no-gutters collapse" id="paragraph-id-{{ paragraph.id() }}">
         <div class="col">
           <div class="row no-gutters">


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-644

Fixes display of step title

Before

<img width="332" alt="Screenshot 2022-09-09 at 14 48 20" src="https://user-images.githubusercontent.com/11267554/189353538-75df44e1-c76b-4b39-aa2f-bbe41f7c1275.png">

After

<img width="332" alt="Screenshot 2022-09-09 at 14 48 17" src="https://user-images.githubusercontent.com/11267554/189353521-521f5648-01ee-43f0-a795-84f7e3d4ef42.png">


