### PR TITLE
Custom docker phpfpm image with wkhtmltopdf

### DIFF
--- a/.docker/phpfpm/Dockerfile
+++ b/.docker/phpfpm/Dockerfile
@@ -1,0 +1,11 @@
+FROM itkdev/php7.4-fpm:latest
+
+# Install wkhtmltopdf
+RUN apt-get update \
+# Dependencies for wkhtmltopdf
+    && apt-get install --yes xfonts-base xfonts-75dpi \
+# Download and install wkhtmltopdf
+    && curl --location https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb > /tmp/wkhtmltox.deb \
+    && dpkg --install /tmp/wkhtmltox.deb \
+# Clean up
+    && rm -rf /tmp/wkhtmltox.deb /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ modules.
 See [docs/development](docs/development/README.md) for details on development.
 
 ```sh
-docker-compose up --detach
+docker-compose up --detach --build
 docker-compose exec phpfpm composer install
 docker-compose exec phpfpm vendor/bin/drush --yes site:install os2loop --existing-config
 # Get the site url
@@ -177,4 +177,4 @@ composer coding-standards-check
 ```sh
 docker run --volume ${PWD}:/app --workdir /app node:16.13.2 yarn install
 docker run --volume ${PWD}:/app --workdir /app node:16.13.2 yarn encore dev
- ```
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3"
 
 networks:
+  frontend:
+    external: true
   app:
     driver: bridge
     internal: false
@@ -22,7 +24,7 @@ services:
       com.symfony.server.service-prefix: 'DATABASE'
 
   phpfpm:
-    image: itkdev/php7.4-fpm:latest
+    build: .docker/phpfpm
     networks:
       - app
     environment:
@@ -44,6 +46,7 @@ services:
     image: nginx:latest
     networks:
       - app
+      - frontend
     depends_on:
       - phpfpm
     ports:
@@ -51,6 +54,12 @@ services:
     volumes:
       - ./.docker/vhost.conf:/etc/nginx/conf.d/default.conf:ro
       - ./:/app:delegated
+    # Let the container be accessible both internally and externally on the same domain.
+    container_name: ${COMPOSE_DOMAIN}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=frontend"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`)"
 
   memcached:
     image: 'memcached:latest'
@@ -65,6 +74,7 @@ services:
     image: mailhog/mailhog
     networks:
       - app
+      - frontend
     ports:
       - "1025"
       - "8025"


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-650

Adds custom docker phpfpm image with `wkhtmltopdf` used by [phpwkhtmltopdf](https://github.com/mikehaertl/phpwkhtmltopdf) (cf. https://github.com/mikehaertl/phpwkhtmltopdf#installation-of-wkhtmltopdf).

Using `wkhtmltopdf` is somewhat old fashioned, but that's what we're currently using in Loop.
