### PR TITLE
SUPP0RT-650: Added phpfpm image with wkhtmltopdf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       com.symfony.server.service-prefix: 'DATABASE'
 
   phpfpm:
-    image: itkdev/php7.4-fpm:latest
+    image: itkdev/php7.4-fpm:wkhtmltopdf
     networks:
       - app
     environment:


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-650

Adds phpfpm image with wkhtmltopdf.

Note: Using the Traefik setup from https://github.com/itk-dev/devops_itkdev-docker (or something similar) is required to actually test PDF generation due to the NGINX docker container not being directly accessible from the PHP container:

```
Error generating document: Failed to generate PDF: Loading pages …
Warning: Failed to load http://0.0.0.0:54182/sites/default/files/css/css_EGKleuQUDoNwiPUbxRf90uVNi3ODyf8p0ucqeltCO2w.css (ignore)
…
```
