### PR TITLE
SUPP0RT-821: Disabled userlogin form cache

### DIFF
--- a/web/profiles/custom/os2loop/modules/os2loop_user_login/src/Helper/Helper.php
+++ b/web/profiles/custom/os2loop/modules/os2loop_user_login/src/Helper/Helper.php
@@ -134,6 +134,10 @@ class Helper {
    */
   public function preprocessBlock(array &$variables) {
     if ('userlogin' === ($variables['elements']['#id'] ?? NULL)) {
+      // Disable cache on the userlogin form to prevent redirects when resetting
+      // password.
+      $variables['#cache']['max-age'] = 0;
+
       // Ignore default login method when resetting password.
       // Note: CurrentPathStack::getPath() claims to return the path without
       // leading slashes, but seems to return it with a leading slash.


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-821

Disables cache on `userlogin` form to prevent redirect to default login method.

