### PR TITLE
OpenID Connect redirect URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- [PR-383](https://github.com/itk-dev/os2loop/pull/383)
+  Fixed OpenID Connect redirect URLs
 - [PR-377](https://github.com/itk-dev/os2loop/pull/377)
   - Security update
   - Code cleanup

--- a/config/sync/openid_connect.settings.yml
+++ b/config/sync/openid_connect.settings.yml
@@ -3,8 +3,8 @@ connect_existing_users: true
 override_registration_settings: true
 end_session_enabled: true
 user_login_display: above
-redirect_login: 'http://os2loop.local.itkdev.dk/user/login'
-redirect_logout: 'http://os2loop.local.itkdev.dk/user/logout'
+redirect_login: /user
+redirect_logout: /
 userinfo_mappings:
   timezone: zoneinfo
   os2loop_user_family_name: family_name


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/_#/tickets/showTicket/6991

#### Description

Fixes OpenID Connect redirect URLs. I'm not sure what the defaults should actually be, but they should not contain `http://os2loop.local.itkdev.dk`.

``` text
phpfpm-1  | NOTICE: PHP message: Uncaught PHP Exception InvalidArgumentException: "The internal path component 'http://os2loop.local.itkdev.dk/user/logout' is external. You are not allowed to specify an external URL together with internal:/." at /app/web/core/lib/Drupal/Core/Url.php line 422
```