### PR TITLE
Cleaned up composer.json and composer.lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -224,11 +224,11 @@
             "drupal/masquerade": {
                 "https://www.drupal.org/project/masquerade/issues/2962970#comment-13391256": "https://www.drupal.org/files/issues/2019-12-13/temporary%20unmask%20workaround-2962970-8.patch"
             },
-            "drupal/toc_api": {
-                "https://www.drupal.org/project/toc_api/issues/3417862": "https://www.drupal.org/files/issues/2024-02-07/toc_api-3417862-anchors_add_01-1.patch"
-            },
             "drupal/openid_connect": {
                 "Fix render bug, inspired by https://drupal.stackexchange.com/a/251931": "patches/openid_connect-renderRootError.patch"
+            },
+            "drupal/toc_api": {
+                "https://www.drupal.org/project/toc_api/issues/3417862": "https://www.drupal.org/files/issues/2024-02-07/toc_api-3417862-anchors_add_01-1.patch"
             }
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adc3032390e71cb010e8b389955e1f0f",
+    "content-hash": "2064f4843b980734c64a1412221c79e2",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Cleans up `composer.json` and `compose.lock`. Does not update `CHANGELOG.md`.