### PR TITLE
7840: Improved handling of empty step title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- [PR-395](https://github.com/itk-dev/os2loop/pull/395)
+  7840: Improved handling of empty step title
 - [PR-394](https://github.com/itk-dev/os2loop/pull/394)
   Made `NGINX_FASTCGI_READ_TIMEOUT` have effect
 

--- a/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/paragraph--os2loop-documents-step.html.twig
+++ b/web/profiles/custom/os2loop/themes/os2loop_theme/templates/content-entities/paragraph--os2loop-documents-step.html.twig
@@ -49,8 +49,6 @@
   ]
 %}
 
-{% set has_title = content.os2loop_documents_step_title['#title'] is not null %}
-
 {% set expanded = app.request.query.get('expanded') %}
 {% set class_collapsed = not expanded ? 'collapsed' %}
 
@@ -61,13 +59,13 @@
       {% if 'print/pdf' in url('<current>')['#markup'] %}
         <span class="{{ class_collapsed }} step--collapse-toggle">
           <span class="bold">
-            {{ has_title ? content.os2loop_documents_step_title : content.os2loop_documents_step_text }}
+            {{ content.os2loop_documents_step_title }}
           </span>
         </span>
       {% else %}
         <a class="{{ class_collapsed }} step--collapse-toggle" type="button" data-toggle="collapse" data-target="#paragraph-id-{{ paragraph.id() }}">
-          <span class="bold {{ has_title ? 'line-clamp-1' }}">
-            {{ has_title ? content.os2loop_documents_step_title : content.os2loop_documents_step_text }}
+          <span class="bold">
+            {{ content.os2loop_documents_step_title }}
           </span>
         </a>
       {% endif %}


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7840>

#### Description

Removed hack trying to work around empty title on a step. The hack made the step content appear twice.

#### Screenshot of the result

Before:

<img width="914" height="515" alt="Screenshot 2026-06-29 at 11 27 32" src="https://github.com/user-attachments/assets/e448efe0-a5db-4c0c-b406-14cf580bda94" />
<img width="914" height="515" alt="Screenshot 2026-06-29 at 11 27 29" src="https://github.com/user-attachments/assets/a3fbdcc4-0cd2-4b5b-b865-d0cab45d73f1" />

Notice duplicated content (“Når der er behov for at …”).

After:

<img width="914" height="515" alt="Screenshot 2026-06-29 at 11 29 10" src="https://github.com/user-attachments/assets/9d181dd5-4953-48cb-807c-68058db5caba" />
<img width="914" height="515" alt="Screenshot 2026-06-29 at 11 29 06" src="https://github.com/user-attachments/assets/547de904-c424-4df3-824b-574a679015b8" />


If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
