### PR TITLE
Docker compose setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- [PR-398](https://github.com/itk-dev/os2loop/pull/398)
+  Updated `node` docker compose setup
+
 ## [1.4.0] - 2026-06-29
 
 - [PR-396](https://github.com/itk-dev/os2loop/pull/396)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,14 +2,6 @@ include:
   - docker-compose.oidc.yml
 
 services:
-  node:
-    image: node:20
-    working_dir: /app
-    networks:
-      - app
-    volumes:
-      - ./web/profiles/custom/os2loop/themes/os2loop_theme:/app
-
   phpfpm:
     environment:
       - PHP_MAX_EXECUTION_TIME=300
@@ -19,3 +11,11 @@ services:
     environment:
       # Match PHP_MAX_EXECUTION_TIME above
       - NGINX_FASTCGI_READ_TIMEOUT=300
+
+  node:
+    image: node:20
+    profiles:
+      - dev
+    working_dir: /app
+    volumes:
+      - ./web/profiles/custom/os2loop/themes/os2loop_theme:/app

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -14,7 +14,5 @@ services:
     profiles:
       - dev
     working_dir: /app
-    networks:
-      - app
     volumes:
       - ./web/profiles/custom/os2loop/themes/os2loop_theme:/app

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -11,6 +11,8 @@ services:
 
   node:
     image: node:20
+    profiles:
+      - dev
     working_dir: /app
     networks:
       - app


### PR DESCRIPTION
#### Link to ticket

<https://leantime.itkdev.dk/_#/tickets/showTicket/7946>

#### Description

Updated docker compose overrides:

- Adds `dev` profile to `node` service to prevent it from starting during deployment (cf. <https://woodpecker.itkdev.dk/repos/21/pipeline/65>)
- Aligns and cleans up docker compose overrides

